### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -16,7 +16,7 @@ sys.path.append(os.path.abspath('tools/sphinxext'))
 
 # General substitutions.
 project = 'Mod_python'
-copyright = '1990-%s, Apache Software Foundation, Gregory Trubetskoy' % time.strftime('%Y')
+copyright = '1990-{0!s}, Apache Software Foundation, Gregory Trubetskoy'.format(time.strftime('%Y'))
 
 # The default replacements for |version| and |release|.
 #

--- a/Doc/tools/roman.py
+++ b/Doc/tools/roman.py
@@ -69,7 +69,7 @@ def fromRoman(s):
     if not s:
         raise InvalidRomanNumeralError('Input can not be blank')
     if not romanNumeralPattern.search(s):
-        raise InvalidRomanNumeralError('Invalid Roman numeral: %s' % s)
+        raise InvalidRomanNumeralError('Invalid Roman numeral: {0!s}'.format(s))
 
     result = 0
     index = 0

--- a/Doc/tools/rstlint.py
+++ b/Doc/tools/rstlint.py
@@ -42,7 +42,7 @@ directives = [
 ]
 
 all_directives = '(' + '|'.join(directives) + ')'
-seems_directive_re = re.compile(r'\.\. %s([^a-z:]|:(?!:))' % all_directives)
+seems_directive_re = re.compile(r'\.\. {0!s}([^a-z:]|:(?!:))'.format(all_directives))
 default_role_re = re.compile(r'(^| )`\w([^`]*?\w)?`($| )')
 leaked_markup_re = re.compile(r'[a-z]::[^=]|:[a-z]+:|`|\.\.\s*\w+:')
 
@@ -73,7 +73,7 @@ def check_syntax(fn, lines):
     try:
         compile(code, fn, 'exec')
     except SyntaxError, err:
-        yield err.lineno, 'not compilable: %s' % err
+        yield err.lineno, 'not compilable: {0!s}'.format(err)
 
 
 @checker('.rst', severity=2)
@@ -124,18 +124,18 @@ def check_leaked_markup(fn, lines):
     """
     for lno, line in enumerate(lines):
         if leaked_markup_re.search(line):
-            yield lno+1, 'possibly leaked markup: %r' % line
+            yield lno+1, 'possibly leaked markup: {0!r}'.format(line)
 
 
 def main(argv):
     usage = '''\
-Usage: %s [-v] [-f] [-s sev] [-i path]* [path]
+Usage: {0!s} [-v] [-f] [-s sev] [-i path]* [path]
 
 Options:  -v       verbose (print all checked file names)
           -f       enable checkers that yield many false positives
           -s sev   only show problems with severity >= sev
           -i path  ignore subdir or file path
-''' % argv[0]
+'''.format(argv[0])
     try:
         gopts, args = getopt.getopt(argv[1:], 'vfs:i:')
     except getopt.GetoptError:
@@ -165,7 +165,7 @@ Options:  -v       verbose (print all checked file names)
         return 2
 
     if not exists(path):
-        print 'Error: path %s does not exist' % path
+        print 'Error: path {0!s} does not exist'.format(path)
         return 2
 
     count = defaultdict(int)
@@ -196,13 +196,13 @@ Options:  -v       verbose (print all checked file names)
                 continue
 
             if verbose:
-                print 'Checking %s...' % fn
+                print 'Checking {0!s}...'.format(fn)
 
             try:
                 with open(fn, 'r') as f:
                     lines = list(f)
             except (IOError, OSError), err:
-                print '%s: cannot open: %s' % (fn, err)
+                print '{0!s}: cannot open: {1!s}'.format(fn, err)
                 count[4] += 1
                 continue
 
@@ -212,20 +212,19 @@ Options:  -v       verbose (print all checked file names)
                 csev = checker.severity
                 if csev >= severity:
                     for lno, msg in checker(fn, lines):
-                        print >>out, '[%d] %s:%d: %s' % (csev, fn, lno, msg)
+                        print >>out, '[{0:d}] {1!s}:{2:d}: {3!s}'.format(csev, fn, lno, msg)
                         count[csev] += 1
     if verbose:
         print
     if not count:
         if severity > 1:
-            print 'No problems with severity >= %d found.' % severity
+            print 'No problems with severity >= {0:d} found.'.format(severity)
         else:
             print 'No problems found.'
     else:
         for severity in sorted(count):
             number = count[severity]
-            print '%d problem%s with severity %d found.' % \
-                  (number, number > 1 and 's' or '', severity)
+            print '{0:d} problem{1!s} with severity {2:d} found.'.format(number, number > 1 and 's' or '', severity)
     return int(bool(count))
 
 

--- a/Doc/tools/serve.py
+++ b/Doc/tools/serve.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     path = sys.argv[1]
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
     httpd = simple_server.make_server('', port, app)
-    print "Serving %s on port %s, control-C to stop" % (path, port)
+    print "Serving {0!s} on port {1!s}, control-C to stop".format(path, port)
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/Doc/tools/sphinxext/suspicious.py
+++ b/Doc/tools/sphinxext/suspicious.py
@@ -111,8 +111,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
     def finish(self):
         unused_rules = [rule for rule in self.rules if not rule.used]
         if unused_rules:
-            self.warn('Found %s/%s unused rules:' %
-                      (len(unused_rules), len(self.rules)))
+            self.warn('Found {0!s}/{1!s} unused rules:'.format(len(unused_rules), len(self.rules)))
             for rule in unused_rules:
                 self.info(repr(rule))
         return
@@ -147,7 +146,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
         if not self.any_issue: self.info()
         self.any_issue = True
         self.write_log_entry(lineno, issue, text)
-        self.warn('[%s:%d] "%s" found in "%-.120s"' % (
+        self.warn('[{0!s}:{1:d}] "{2!s}" found in "{3:<.120!s}"'.format(
                 self.docname.encode(sys.getdefaultencoding(),'replace'),
                 lineno,
                 issue.encode(sys.getdefaultencoding(),'replace'),
@@ -176,7 +175,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
         for i, row in enumerate(csv.reader(f)):
             if len(row) != 4:
                 raise ValueError(
-                    "wrong format in %s, line %d: %s" % (filename, i+1, row))
+                    "wrong format in {0!s}, line {1:d}: {2!s}".format(filename, i+1, row))
             docname, lineno, issue, text = row
             docname = docname.decode('utf-8')
             if lineno: lineno = int(lineno)
@@ -186,7 +185,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
             rule = Rule(docname, lineno, issue, text)
             rules.append(rule)
         f.close()
-        self.info('done, %d rules loaded' % len(self.rules))
+        self.info('done, {0:d} rules loaded'.format(len(self.rules)))
 
 
 def get_lineno(node):

--- a/dist/win32_postinstall.py
+++ b/dist/win32_postinstall.py
@@ -34,7 +34,7 @@ def getApacheDirOptions():
             def subkeynames(self):
                 return []
             def getvalue(self, valuename):
-                raise AttributeError("Cannot access registry value %r: key does not exist" % (valuename))
+                raise AttributeError("Cannot access registry value {0!r}: key does not exist".format((valuename)))
         class regkey:
             """simple wrapper for registry functions that closes keys nicely..."""
             def __init__(self, parent, subkeyname):
@@ -51,7 +51,7 @@ def getApacheDirOptions():
                try:
                    return win32api.RegQueryValueEx(self.key, valuename)
                except win32api.error:
-                   raise AttributeError("Cannot access registry value %r" % (valuename))
+                   raise AttributeError("Cannot access registry value {0!r}".format((valuename)))
             def __del__(self):
                if hasattr(self, "key"):
                    win32api.RegCloseKey(self.key)
@@ -120,14 +120,14 @@ if len(sys.argv) == 1 or (len(sys.argv) > 1 and sys.argv[1] != "-remove"):
         1. This script does not attempt to modify Apache configuration,
            you must do it manually:
 
-           Edit %s,
+           Edit {0!s},
            find where other LoadModule lines are and add this:
                 LoadModule python_module modules/mod_python.so
 
         2. Now test your installation using the instructions at this link:
            http://www.modpython.org/live/current/doc-html/inst-testing.html
 
-        """ % os.path.join(apachedir, "conf", "httpd.conf")
+        """.format(os.path.join(apachedir, "conf", "httpd.conf"))
 
     else:
 
@@ -136,17 +136,17 @@ if len(sys.argv) == 1 or (len(sys.argv) > 1 and sys.argv[1] != "-remove"):
         1. It appears that you do not have Tkinter installed,
            which is required for a part of this installation.
            Therefore you must manually take
-           "%s"
+           "{0!s}"
            and copy it to your Apache modules directory.
 
         2. This script does not attempt to modify Apache configuration,
            you must do it manually:
 
-           Edit %s,
+           Edit {1!s},
            find where other LoadModule lines and add this:
                 LoadModule python_module modules/mod_python.so
 
         3. Now test your installation using the instructions at this link:
            http://www.modpython.org/live/current/doc-html/inst-testing.html
 
-        """ % (mp, os.path.join(apachedir, "conf", "httpd.conf"))
+        """.format(mp, os.path.join(apachedir, "conf", "httpd.conf"))

--- a/lib/python/mod_python/Cookie.py
+++ b/lib/python/mod_python/Cookie.py
@@ -82,7 +82,7 @@ class metaCookie(type):
                 try:
                     t = time.strptime(value, "%a, %d-%b-%Y %H:%M:%S GMT")
                 except ValueError:
-                    raise ValueError("Invalid expires time: %s" % value)
+                    raise ValueError("Invalid expires time: {0!s}".format(value))
                 t = time.mktime(t)
             else:
                 # otherwise assume it's a number
@@ -91,7 +91,7 @@ class metaCookie(type):
                 value = time.strftime("%a, %d-%b-%Y %H:%M:%S GMT",
                                       time.gmtime(t))
 
-            self._expires = "%s" % value
+            self._expires = "{0!s}".format(value)
 
         def get_expires(self):
             return self._expires
@@ -156,17 +156,17 @@ class Cookie(_metaCookie):
         browsers out there.
         """
 
-        result = ["%s=%s" % (self.name, self.value)]
+        result = ["{0!s}={1!s}".format(self.name, self.value)]
         for name in self._valid_attr:
             if hasattr(self, name):
                 if name in ("secure", "discard", "httponly"):
                     result.append(name)
                 else:
-                    result.append("%s=%s" % (name, getattr(self, name)))
+                    result.append("{0!s}={1!s}".format(name, getattr(self, name)))
         return "; ".join(result)
 
     def __repr__(self):
-        return '<%s: %s>' % (self.__class__.__name__,
+        return '<{0!s}: {1!s}>'.format(self.__class__.__name__,
                                 str(self))
 
 
@@ -223,14 +223,14 @@ class SignedCookie(Cookie):
 
     def __str__(self):
 
-        result = ["%s=%s%s" % (self.name, self.hexdigest(self.value),
+        result = ["{0!s}={1!s}{2!s}".format(self.name, self.hexdigest(self.value),
                                self.value)]
         for name in self._valid_attr:
             if hasattr(self, name):
                 if name in ("secure", "discard", "httponly"):
                     result.append(name)
                 else:
-                    result.append("%s=%s" % (name, getattr(self, name)))
+                    result.append("{0!s}={1!s}".format(name, getattr(self, name)))
         return "; ".join(result)
 
     def unsign(self, secret):
@@ -244,7 +244,7 @@ class SignedCookie(Cookie):
             self.value = val
             self.__data__["secret"] = secret
         else:
-            raise CookieError("Incorrectly Signed Cookie: %s=%s" % (self.name, self.value))
+            raise CookieError("Incorrectly Signed Cookie: {0!s}={1!s}".format(self.name, self.value))
 
 
 class MarshalCookie(SignedCookie):
@@ -296,13 +296,13 @@ class MarshalCookie(SignedCookie):
         # separated by \n or \r\n
         m = ''.join(m.split())
 
-        result = ["%s=%s%s" % (self.name, self.hexdigest(m), m)]
+        result = ["{0!s}={1!s}{2!s}".format(self.name, self.hexdigest(m), m)]
         for name in self._valid_attr:
             if hasattr(self, name):
                 if name in ("secure", "discard", "httponly"):
                     result.append(name)
                 else:
-                    result.append("%s=%s" % (name, getattr(self, name)))
+                    result.append("{0!s}={1!s}".format(name, getattr(self, name)))
         return "; ".join(result)
 
     def unmarshal(self, secret):
@@ -312,12 +312,12 @@ class MarshalCookie(SignedCookie):
         try:
             data = base64.decodestring(self.value)
         except:
-            raise CookieError("Cannot base64 Decode Cookie: %s=%s" % (self.name, self.value))
+            raise CookieError("Cannot base64 Decode Cookie: {0!s}={1!s}".format(self.name, self.value))
 
         try:
             self.value = marshal.loads(data)
         except (EOFError, ValueError, TypeError):
-            raise CookieError("Cannot Unmarshal Cookie: %s=%s" % (self.name, self.value))
+            raise CookieError("Cannot Unmarshal Cookie: {0!s}={1!s}".format(self.name, self.value))
 
 
 # This is a simplified and in some places corrected

--- a/lib/python/mod_python/Session.py
+++ b/lib/python/mod_python/Session.py
@@ -126,7 +126,7 @@ def _new_sid(req):
     rnd2 = g.randint(0, 999999999)
     ip = req.connection.remote_ip
 
-    return md5_hash("%d%d%d%d%s" % (t, pid, rnd1, rnd2, ip))
+    return md5_hash("{0:d}{1:d}{2:d}{3:d}{4!s}".format(t, pid, rnd1, rnd2, ip))
 
 validate_sid_re = re.compile('[0-9a-f]{32}$')
 
@@ -186,7 +186,7 @@ class BaseSession(dict):
                     # Supplied explicitly by user of the class,
                     # raise an exception and make the user code
                     # deal with it.
-                    raise ValueError("Invalid Session ID: sid=%s" % sid)
+                    raise ValueError("Invalid Session ID: sid={0!s}".format(sid))
                 else:
                     # Derived from the cookie sent by browser,
                     # wipe it out so it gets replaced with a
@@ -544,7 +544,7 @@ class FileSession(BaseSession):
                 s = StringIO()
                 traceback.print_exc(file=s)
                 s = s.getvalue()
-                self._req.log_error('Error while loading a session : %s'%s)
+                self._req.log_error('Error while loading a session : {0!s}'.format(s))
                 return None
         finally:
             self.unlock_file()
@@ -566,7 +566,7 @@ class FileSession(BaseSession):
                 s = StringIO()
                 traceback.print_exc(file=s)
                 s = s.getvalue()
-                self._req.log_error('Error while saving a session : %s'%s)
+                self._req.log_error('Error while saving a session : {0!s}'.format(s))
         finally:
             self.unlock_file()
 
@@ -617,8 +617,7 @@ def filesession_cleanup(data):
     grace_period = data['grace_period']
     cleanup_time_limit = data['cleanup_time_limit']
 
-    req.log_error('FileSession cleanup: (fast=%s, verify=%s) ...'
-                    % (fast_cleanup,verify_cleanup),
+    req.log_error('FileSession cleanup: (fast={0!s}, verify={1!s}) ...'.format(fast_cleanup, verify_cleanup),
                     apache.APLOG_NOTICE)
 
     lockfile = os.path.join(sessdir,'.mp_sess.lck')
@@ -670,7 +669,7 @@ def filesession_cleanup(data):
         filelist =  os.listdir(sessdir)
         dir_index = list(range(0,256))[next_i:]
         for i in dir_index:
-            path = '%s/%s' % (sessdir,'%02x' % i)
+            path = '{0!s}/{1!s}'.format(sessdir, '{0:02x}'.format(i))
             if not os.path.exists(path):
                 continue
 
@@ -704,8 +703,7 @@ def filesession_cleanup(data):
                     s = StringIO()
                     traceback.print_exc(file=s)
                     s = s.getvalue()
-                    req.log_error('FileSession cleanup error: %s'
-                                    % (s),
+                    req.log_error('FileSession cleanup error: {0!s}'.format((s)),
                                     apache.APLOG_NOTICE)
 
             next_i = (i + 1) % 256
@@ -716,19 +714,17 @@ def filesession_cleanup(data):
         total_time += time.time() - start_time
         if next_i == 0:
             # next_i can only be 0 when the full cleanup has run to completion
-            req.log_error("FileSession cleanup: deleted %d of %d in %.4f seconds"
-                            % (expired_file_count, total_file_count, total_time),
+            req.log_error("FileSession cleanup: deleted {0:d} of {1:d} in {2:.4f} seconds".format(expired_file_count, total_file_count, total_time),
                             apache.APLOG_NOTICE)
             expired_file_count = 0
             total_file_count = 0
             total_time = 0.0
         else:
-            req.log_error("FileSession cleanup incomplete: next cleanup will start at index %d (%02x)"
-                        % (next_i, next_i),
+            req.log_error("FileSession cleanup incomplete: next cleanup will start at index {0:d} ({1:02x})".format(next_i, next_i),
                         apache.APLOG_NOTICE)
 
         status_file = open(os.path.join(sessdir, 'fs_status.txt'), 'w')
-        status_file.write('%s %d %d %d %f\n' % (stat_version, next_i, expired_file_count, total_file_count, total_time))
+        status_file.write('{0!s} {1:d} {2:d} {3:d} {4:f}\n'.format(stat_version, next_i, expired_file_count, total_file_count, total_time))
         status_file.close()
 
         try:
@@ -742,7 +738,7 @@ def filesession_cleanup(data):
 def make_filesession_dirs(sess_dir):
     """Creates the directory structure used for storing session files"""
     for i in range(0,256):
-        path = os.path.join(sess_dir, '%02x' % i)
+        path = os.path.join(sess_dir, '{0:02x}'.format(i))
         if not os.path.exists(path):
             os.makedirs(path,  stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP)
 
@@ -818,7 +814,7 @@ def Session(req, sid=0, secret=None, timeout=0, lock=1):
     else:
         # TODO Add capability to load a user defined class
         # For now, just raise an exception.
-        raise Exception('Unknown session type %s' % sess_type)
+        raise Exception('Unknown session type {0!s}'.format(sess_type))
 
     return sess(req, sid=sid, secret=secret,
                          timeout=timeout, lock=lock)

--- a/lib/python/mod_python/apache.py
+++ b/lib/python/mod_python/apache.py
@@ -142,7 +142,7 @@ class CallBack:
                 result = obj(conn)
 
             assert (result.__class__ is int), \
-                   "ConnectionHandler '%s' returned invalid return code." % handler
+                   "ConnectionHandler '{0!s}' returned invalid return code.".format(handler)
 
         except:
             # Error (usually parsing)
@@ -263,7 +263,7 @@ class CallBack:
 
                 if result.__class__ is not int:
                     s = "Value raised with SERVER_RETURN is invalid. It is a "
-                    s = s + "%s, but it must be a tuple or an int." % result.__class__
+                    s = s + "{0!s}, but it must be a tuple or an int.".format(result.__class__)
                     _apache.log_error(s, APLOG_ERR, req.server)
 
                     return
@@ -358,7 +358,7 @@ class CallBack:
                         obj = module.__dict__[obj_str]
                     except:
                         if not hlist.silent:
-                            s = "module '%s' contains no '%s'" % (module.__file__, obj_str)
+                            s = "module '{0!s}' contains no '{1!s}'".format(module.__file__, obj_str)
                             raise AttributeError(s)
                 else:
                     obj = resolve_object(module, obj_str,
@@ -534,7 +534,7 @@ class CallBack:
 
                 # write to log
                 for e in traceback.format_exception(etype, evalue, etb):
-                    s = "%s %s: %s" % (phase, hname, e[:-1])
+                    s = "{0!s} {1!s}: {2!s}".format(phase, hname, e[:-1])
                     if req:
                         req.log_error(s, APLOG_ERR)
                     else:
@@ -547,7 +547,7 @@ class CallBack:
                     req.status = HTTP_INTERNAL_SERVER_ERROR
                     req.content_type = 'text/html'
 
-                    s = '\n<pre>\nMod_python error: "%s %s"\n\n' % (phase, hname)
+                    s = '\n<pre>\nMod_python error: "{0!s} {1!s}"\n\n'.format(phase, hname)
                     for e in traceback.format_exception(etype, evalue, etb):
                         s = s + cgi.escape(e) + '\n'
                     s = s + "</pre>\n"
@@ -623,9 +623,9 @@ def import_module(module_name, autoreload=1, log=0, path=None):
             # Import the module
             if log:
                 if path:
-                    s = "mod_python: (Re)importing module '%s' with path set to '%s'" % (module_name, path)
+                    s = "mod_python: (Re)importing module '{0!s}' with path set to '{1!s}'".format(module_name, path)
                 else:
-                    s = "mod_python: (Re)importing module '%s'" % module_name
+                    s = "mod_python: (Re)importing module '{0!s}'".format(module_name)
                 _apache.log_error(s, APLOG_NOTICE)
 
             parent = None
@@ -701,7 +701,7 @@ def resolve_object(module, obj_str, arg=None, silent=0):
         # this adds a little clarity if we have an attriute error
         if obj == module and not hasattr(module, obj_str):
             if hasattr(module, "__file__"):
-                s = "module '%s' contains no '%s'" % (module.__file__, obj_str)
+                s = "module '{0!s}' contains no '{1!s}'".format(module.__file__, obj_str)
                 raise AttributeError(s)
 
         obj = getattr(obj, obj_str)

--- a/lib/python/mod_python/cache.py
+++ b/lib/python/mod_python/cache.py
@@ -288,7 +288,7 @@ class HTTPEntity(object):
         self.metadata=metadata
 
     def __repr__(self):
-        return 'HTTPEntity(%s, %s)'%(repr(self.entity), self.metadata)
+        return 'HTTPEntity({0!s}, {1!s})'.format(repr(self.entity), self.metadata)
 
     def __str__(self):
         return self.entity

--- a/lib/python/mod_python/httpdconf.py
+++ b/lib/python/mod_python/httpdconf.py
@@ -37,14 +37,14 @@ class Directive:
 
     def __repr__(self):
         i = " " * self.indent
-        s = i + '%s(%s)' % (self.name, repr(self.val))
+        s = i + '{0!s}({1!s})'.format(self.name, repr(self.val))
         if self.flipslash:
             s = s.replace("\\", "/")
         return s
 
     def __str__(self):
         i = " " * self.indent
-        s = i + '%s %s\n' % (self.name, self.val)
+        s = i + '{0!s} {1!s}\n'.format(self.name, self.val)
         if self.flipslash:
             s = s.replace("\\", "/")
         return s
@@ -69,8 +69,8 @@ class Container:
         s = i + 'Container('
         for arg in self.args:
             arg.indent = self.indent + 4
-            s += "\n%s," % repr(arg)
-        s += "\n" + i + (self.only_if and ('    only_if=%s)' % repr(self.only_if)) or ')')
+            s += "\n{0!s},".format(repr(arg))
+        s += "\n" + i + (self.only_if and ('    only_if={0!s})'.format(repr(self.only_if))) or ')')
         return s
 
     def __str__(self):
@@ -79,7 +79,7 @@ class Container:
         s = ""
         for arg in self.args:
             arg.indent = self.indent
-            s += "%s" % str(arg)
+            s += "{0!s}".format(str(arg))
 
         return s
 
@@ -94,24 +94,24 @@ class ContainerTag:
 
     def __repr__(self):
         i = " " * self.indent
-        s = i + "%s(%s," % (self.tag, repr(self.attr))
+        s = i + "{0!s}({1!s},".format(self.tag, repr(self.attr))
         if self.flipslash:
             s = s.replace("\\", "/")
         for arg in self.args:
             arg.indent = self.indent + 4
-            s += "\n%s," % repr(arg)
+            s += "\n{0!s},".format(repr(arg))
         s += "\n" + i + ")"
         return s
 
     def __str__(self):
         i = " " * self.indent
-        s = i + "<%s %s>\n" % (self.tag, self.attr)
+        s = i + "<{0!s} {1!s}>\n".format(self.tag, self.attr)
         if self.flipslash:
             s = s.replace("\\", "/")
         for arg in self.args:
             arg.indent = self.indent + 2
-            s += "%s" % str(arg)
-        s += i + "</%s>\n" % self.tag
+            s += "{0!s}".format(str(arg))
+        s += i + "</{0!s}>\n".format(self.tag)
         return s
 
 class Comment:
@@ -123,7 +123,7 @@ class Comment:
     def __repr__(self):
         i = " " * self.indent
         lines = self.comment.splitlines()
-        s = i + "Comment(%s" % repr(lines[0]+"\n")
+        s = i + "Comment({0!s}".format(repr(lines[0]+"\n"))
         for line in lines[1:]:
             s += "\n        " + i + repr(line+"\n")
         s += ")"
@@ -133,7 +133,7 @@ class Comment:
         i = " " * self.indent
         s = ""
         for line in self.comment.splitlines():
-            s += i + '# %s\n' % line
+            s += i + '# {0!s}\n'.format(line)
         return s
 
 ## directives
@@ -396,7 +396,7 @@ def quote_if_space(s):
     # no spaces, but needs them otherwise,
     # TODO: Is this still true?
     if s.find(" ") != -1:
-        s = '"%s"' % s
+        s = '"{0!s}"'.format(s)
     return s
 
 def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="logs",
@@ -407,7 +407,7 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
 
     conf_path = os.path.join(server_root, conf, conf_name)
     if os.path.exists(conf_path) and not replace_config:
-        print('Error: %s already exists, aborting.' % repr(conf_path), file=sys.stderr)
+        print('Error: {0!s} already exists, aborting.'.format(repr(conf_path)), file=sys.stderr)
         return
 
     if createdirs:
@@ -416,29 +416,29 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
                         os.path.join(server_root, conf),
                         os.path.join(server_root, logs)]:
             if os.path.isdir(dirname):
-                print("Warning: directory %s already exists, continuing." % repr(dirname), file=sys.stderr)
+                print("Warning: directory {0!s} already exists, continuing.".format(repr(dirname)), file=sys.stderr)
             else:
-                print("Creating directory %s." % repr(dirname), file=sys.stderr)
+                print("Creating directory {0!s}.".format(repr(dirname)), file=sys.stderr)
                 os.mkdir(dirname)
 
         # try to find mime.types
         mime_types_dest = os.path.join(server_root, conf, 'mime.types')
         if os.path.isfile(mime_types_dest):
-            print("Warning: file %s already exists, continuing." % repr(mime_types_dest), file=sys.stderr)
+            print("Warning: file {0!s} already exists, continuing.".format(repr(mime_types_dest)), file=sys.stderr)
         else:
             for mime_types_dir in [mod_python.version.SYSCONFDIR, '/etc']:
                 mime_types_src = os.path.join(mime_types_dir, 'mime.types')
                 if os.path.isfile(mime_types_src):
-                    print("Copying %s to %s" % (repr(mime_types_src), repr(mime_types_dest)), file=sys.stderr)
+                    print("Copying {0!s} to {1!s}".format(repr(mime_types_src), repr(mime_types_dest)), file=sys.stderr)
                     shutil.copy(mime_types_src, mime_types_dest)
                     break
 
     mime_types = os.path.join(conf, "mime.types")
     if not os.path.exists(os.path.join(server_root, mime_types)):
-        print("Warning: file %s does not exist." % repr(os.path.join(server_root, mime_types)), file=sys.stderr)
+        print("Warning: file {0!s} does not exist.".format(repr(os.path.join(server_root, mime_types))), file=sys.stderr)
 
     if not os.path.isdir(os.path.join(server_root, htdocs)):
-        print("Warning: %s does not exist or not a directory." % repr(os.path.join(server_root, htdocs)), file=sys.stderr)
+        print("Warning: {0!s} does not exist or not a directory.".format(repr(os.path.join(server_root, htdocs))), file=sys.stderr)
 
     modpath = mod_python.version.LIBEXECDIR
 
@@ -468,7 +468,7 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
         ['alias_module', 'mod_alias.so'],
         ]:
         modules.append(
-            LoadModule("%s %s" % (module[0], quote_if_space(os.path.join(modpath, module[1]))))
+            LoadModule("{0!s} {1!s}".format(module[0], quote_if_space(os.path.join(modpath, module[1]))))
             )
 
     main = Container(Comment("\nMain configuration options:\n\n"),
@@ -481,7 +481,7 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
                                only_if="mod_python.version.HTTPD_VERSION[0:3] < '2.4'"),
 
                      LogFormat(r'"%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined'),
-                     CustomLog("%s combined" % quote_if_space(os.path.join(logs, "access_log"))),
+                     CustomLog("{0!s} combined".format(quote_if_space(os.path.join(logs, "access_log")))),
                      ErrorLog(quote_if_space(os.path.join(logs, "error_log"))),
                      LogLevel("warn"),
 
@@ -500,7 +500,7 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
                      )
 
     mp = Container(Comment("\nmod_python-specific options:\n\n"),
-                   LoadModule("python_module %s" % quote_if_space(quote_if_space(os.path.join(modpath, 'mod_python.so')))),
+                   LoadModule("python_module {0!s}".format(quote_if_space(quote_if_space(os.path.join(modpath, 'mod_python.so'))))),
                    SetHandler("mod_python"),
                    Comment("PythonDebug On"),
                    PythonHandler(pythonhandler),
@@ -511,7 +511,7 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
         for p in pythonpath:
             pp += repr(p)+","
         pp += "]"
-        mp.append(PythonPath('"%s"' % pp))
+        mp.append(PythonPath('"{0!s}"'.format(pp)))
     for po in pythonoptions:
         mp.append(PythonOption(po))
     for c in mp_comments:
@@ -527,7 +527,7 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
     config.append(main)
     config.append(mp)
 
-    s = """#!%s
+    s = """#!{0!s}
 
 #
 # This config was auto-generated, but you can edit it!
@@ -535,11 +535,11 @@ def write_basic_config(server_root, listen='0.0.0.0:8888', conf="conf", logs="lo
 # running it. We recommend you run it like this:
 # $ mod_python genconfig <this filename> > <new apache confg>
 #\n
-""" % mod_python.version.PYTHON_BIN
+""".format(mod_python.version.PYTHON_BIN)
     s += "from mod_python.httpdconf import *\n\n"
     s += "config = " + repr(config)
     s += "\n\nprint(config)\n"
 
-    print("Writing %s." % repr(conf_path), file=sys.stderr)
+    print("Writing {0!s}.".format(repr(conf_path)), file=sys.stderr)
     open(conf_path, 'w').write(s)
     return conf_path

--- a/lib/python/mod_python/psp.py
+++ b/lib/python/mod_python/psp.py
@@ -304,8 +304,8 @@ class PSP:
 
         req.write("<table>\n<tr>")
         for s in ("", "&nbsp;PSP-produced Python Code:",
-                  "&nbsp;%s:" % filename):
-            req.write("<td><tt>%s</tt></td>" % s)
+                  "&nbsp;{0!s}:".format(filename)):
+            req.write("<td><tt>{0!s}</tt></td>".format(s))
         req.write("</tr>\n")
 
         n = 1
@@ -316,10 +316,10 @@ class PSP:
                 right = ""
             else:
                 right = escape(source[n-1]).replace("\t", " "*4).replace(" ", "&nbsp;")
-            for s in ("%d.&nbsp;" % n,
-                      "<font color=blue>%s</font>" % left,
-                      "&nbsp;<font color=green>%s</font>" % right):
-                req.write("<td><tt>%s</tt></td>" % s)
+            for s in ("{0:d}.&nbsp;".format(n),
+                      "<font color=blue>{0!s}</font>".format(left),
+                      "&nbsp;<font color=green>{0!s}</font>".format(right)):
+                req.write("<td><tt>{0!s}</tt></td>".format(s))
             req.write("</tr>\n")
 
             n += 1
@@ -391,7 +391,7 @@ def dbm_cache_store(srv, dbmfile, filename, mtime, val):
     _apache._global_lock(srv, None, 0)
     try:
         dbm = dbm_type.open(dbmfile, 'c')
-        dbm[filename] = "%d %s" % (mtime, code2str(val))
+        dbm[filename] = "{0:d} {1!s}".format(mtime, code2str(val))
     finally:
         try: dbm.close()
         except: pass

--- a/lib/python/mod_python/publisher.py
+++ b/lib/python/mod_python/publisher.py
@@ -80,9 +80,9 @@ class PageCache(ModuleCache):
         log=int(config.get("PythonDebug", 0))
         if log:
             if entry._value is NOT_INITIALIZED:
-                req.log_error('Publisher loading page %s'%req.filename, apache.APLOG_NOTICE)
+                req.log_error('Publisher loading page {0!s}'.format(req.filename), apache.APLOG_NOTICE)
             else:
-                req.log_error('Publisher reloading page %s'%req.filename, apache.APLOG_NOTICE)
+                req.log_error('Publisher reloading page {0!s}'.format(req.filename), apache.APLOG_NOTICE)
         return ModuleCache.build(self, key, req, opened, entry)
 
 page_cache = PageCache()
@@ -308,7 +308,7 @@ def process_auth(req, object, realm="unknown", user=None, passwd=None):
 
         if not user:
             # note that Opera supposedly doesn't like spaces around "=" below
-            s = 'Basic realm="%s"' % realm
+            s = 'Basic realm="{0!s}"'.format(realm)
             req.err_headers_out["WWW-Authenticate"] = s
             raise apache.SERVER_RETURN(apache.HTTP_UNAUTHORIZED)
 
@@ -321,7 +321,7 @@ def process_auth(req, object, realm="unknown", user=None, passwd=None):
                 rc = __auth__
 
         if not rc:
-            s = 'Basic realm = "%s"' % realm
+            s = 'Basic realm = "{0!s}"'.format(realm)
             req.err_headers_out["WWW-Authenticate"] = s
             raise apache.SERVER_RETURN(apache.HTTP_UNAUTHORIZED)
 
@@ -496,7 +496,7 @@ def publish_object(req, obj):
             else:
                 req.content_type = 'text/plain'
             if charset is not None:
-                req.content_type += '; charset=%s'%charset
+                req.content_type += '; charset={0!s}'.format(charset)
 
         # Write result even if req.method is 'HEAD' as Apache
         # will discard the final output anyway. Truncating

--- a/lib/python/mod_python/testhandler.py
+++ b/lib/python/mod_python/testhandler.py
@@ -54,7 +54,7 @@ def write_table(req,table):
     req.write('<table border="1">')
     req.write('<tr><th>Key</th><th>Value</th></tr>\n')
     for key in table:
-        req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+        req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
             key,
             table[key]
         ))
@@ -89,53 +89,53 @@ def handler(req):
 
     req.write('<h3>General information</h3>\n')
     req.write('<table border="1">\n')
-    req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
         'Apache version',
         req.subprocess_env.get('SERVER_SOFTWARE')
     ))
-    req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
         'Apache threaded MPM',
         (
             apache.mpm_query(apache.AP_MPMQ_IS_THREADED) and
-            'Yes, maximum %i threads / process'%
-            apache.mpm_query(apache.AP_MPMQ_MAX_THREADS)
+            'Yes, maximum {0:d} threads / process'.format(
+            apache.mpm_query(apache.AP_MPMQ_MAX_THREADS))
         ) or 'No (single thread MPM)'
     ))
-    req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
         'Apache forked MPM',
         (
             apache.mpm_query(apache.AP_MPMQ_IS_FORKED) and
-            'Yes, maximum %i processes'%
-            apache.mpm_query(apache.AP_MPMQ_MAX_DAEMONS)
+            'Yes, maximum {0:d} processes'.format(
+            apache.mpm_query(apache.AP_MPMQ_MAX_DAEMONS))
         ) or 'No (single process MPM)'
     ))
-    req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
         'Apache server root',
         apache.server_root()
     ))
-    req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
         'Apache document root',
         req.document_root()
     ))
     if req.server.error_fname:
-        req.write('<tr><td><code>%s</code></td><td><code>%s</code> (<a href="?view_log=1" target="_new">view last 100 lines</a>)</td></tr>\n'%(
+        req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code> (<a href="?view_log=1" target="_new">view last 100 lines</a>)</td></tr>\n'.format(
             'Apache error log',
             os.path.join(apache.server_root(),req.server.error_fname)
         ))
     else:
-        req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+        req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
             'Apache error log',
             'None'
         ))
-    req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
         'Python sys.version',
         sys.version
     ))
-    req.write('<tr><td><code>%s</code></td><td><pre>%s</pre></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><pre>{1!s}</pre></td></tr>\n'.format(
         'Python sys.path',
         '\n'.join(sys.path)
     ))
-    req.write('<tr><td><code>%s</code></td><td><code>%s</code></td></tr>\n'%(
+    req.write('<tr><td><code>{0!s}</code></td><td><code>{1!s}</code></td></tr>\n'.format(
         'Python interpreter name',
         req.interpreter
     ))

--- a/lib/python/mod_python/util.py
+++ b/lib/python/mod_python/util.py
@@ -93,7 +93,7 @@ class Field:
 
     def __repr__(self):
         """Return printable representation."""
-        return "Field(%s, %s)" % (repr(self.name), repr(self.value))
+        return "Field({0!s}, {1!s})".format(repr(self.name), repr(self.value))
 
     def __getattr__(self, name):
         if name != 'value':
@@ -140,7 +140,7 @@ if PY2:
 
         def __repr__(self):
             """Return printable representation (to pass unit tests)."""
-            return "Field(%s, %s)" % (repr(self.name), repr(self.value))
+            return "Field({0!s}, {1!s})".format(repr(self.name), repr(self.value))
 else:
     class StringField(bytes):
         """ This class is basically a string with
@@ -169,7 +169,7 @@ else:
 
         def __repr__(self):
             """Return printable representation (to pass unit tests)."""
-            return "Field(%s, %s)" % (repr(self.name), repr(self.value))
+            return "Field({0!s}, {1!s})".format(repr(self.name), repr(self.value))
 
 class FieldList(list):
 

--- a/lib/python/mod_python/wsgi.py
+++ b/lib/python/mod_python/wsgi.py
@@ -47,8 +47,7 @@ def handler(req):
 
     if not app:
         req.log_error(
-            'WSGI handler: mod_python.wsgi.application (%s) not found, declining.'
-            % repr(app_str), apache.APLOG_WARNING)
+            'WSGI handler: mod_python.wsgi.application ({0!s}) not found, declining.'.format(repr(app_str)), apache.APLOG_WARNING)
         return apache.DECLINED
 
     ## Build env
@@ -60,8 +59,7 @@ def handler(req):
         # was Location, then it must be mod_python.wsgi.base_uri.
         base_uri = options.get('mod_python.wsgi.base_uri')
         req.log_error(
-            "WSGI handler: req.uri (%s) does not start with mod_python.wsgi.base_uri (%s), declining."
-            % (repr(req.uri), repr(base_uri)), apache.APLOG_WARNING)
+            "WSGI handler: req.uri ({0!s}) does not start with mod_python.wsgi.base_uri ({1!s}), declining.".format(repr(req.uri), repr(base_uri)), apache.APLOG_WARNING)
         return apache.DECLINED
 
     ## Run the app

--- a/test/htdocs/dummymodule.py
+++ b/test/htdocs/dummymodule.py
@@ -1,7 +1,7 @@
 from mod_python import apache
 
-apache.log_error("dummymodule / %s" % apache.interpreter)
+apache.log_error("dummymodule / {0!s}".format(apache.interpreter))
 
 def function():
-    apache.log_error("dummymodule::function / %s" % apache.interpreter)
+    apache.log_error("dummymodule::function / {0!s}".format(apache.interpreter))
     apache.main_server.get_options()["dummymodule::function"] = "1"

--- a/test/htdocs/index.py
+++ b/test/htdocs/index.py
@@ -18,7 +18,7 @@
 # mod_python tests
 
 def index(req):
-    return "test 1 ok, interpreter=%s" % req.interpreter
+    return "test 1 ok, interpreter={0!s}".format(req.interpreter)
 
 def foobar(req):
-    return "test 2 ok, interpreter=%s" % req.interpreter
+    return "test 2 ok, interpreter={0!s}".format(req.interpreter)

--- a/test/htdocs/tests.py
+++ b/test/htdocs/tests.py
@@ -74,7 +74,7 @@ class SimpleTestCase(unittest.TestCase):
         c.log_error("xDEBUGx", apache.APLOG_DEBUG)
 
         # see what's in the log now
-        f = open("%s/logs/error_log" % apache.server_root())
+        f = open("{0!s}/logs/error_log".format(apache.server_root()))
         # for some reason re doesn't like \n, why?
         log = "".join(map(str.strip, f.readlines()))
         f.close()
@@ -104,7 +104,7 @@ class SimpleTestCase(unittest.TestCase):
         a = apache.table({'a':'b'})
         a.add('a', 'c')
         if a['a'] != ['b', 'c']:
-            self.fail('table.add() broken: a["a"] is %s' % repr(a["a"]))
+            self.fail('table.add() broken: a["a"] is {0!s}'.format(repr(a["a"])))
 
         log("Table test DONE.")
 
@@ -138,238 +138,238 @@ class SimpleTestCase(unittest.TestCase):
 
         log("Examining request memebers:")
 
-        log("    req.connection: %s" % repr(req.connection))
+        log("    req.connection: {0!s}".format(repr(req.connection)))
         s = str(type(req.connection))
         if s not in ("<class 'mp_conn'>", "<type 'mp_conn'>"):
-            self.fail("strange req.connection type %s" % repr(s))
+            self.fail("strange req.connection type {0!s}".format(repr(s)))
 
-        log("    req.server: '%s'" % repr(req.server))
+        log("    req.server: '{0!s}'".format(repr(req.server)))
         s = str(type(req.server))
         if s not in ("<class 'mp_server'>", "<type 'mp_server'>"):
-            self.fail("strange req.server type %s" % repr(s))
+            self.fail("strange req.server type {0!s}".format(repr(s)))
 
         for x in ((req.next, "next"),
                   (req.prev, "prev"),
                   (req.main, "main")):
             val, name = x
-            log("    req.%s: '%s'" % (name, repr(val)))
+            log("    req.{0!s}: '{1!s}'".format(name, repr(val)))
             if val:
-                self.fail("strange, req.%s should be None, not %s" % (name, repr(val)))
+                self.fail("strange, req.{0!s} should be None, not {1!s}".format(name, repr(val)))
 
-        log("    req.the_request: '%s'" % req.the_request)
+        log("    req.the_request: '{0!s}'".format(req.the_request))
         if not re.match(r"GET /.* HTTP/1\.", req.the_request):
-            self.fail("strange req.the_request %s" % repr(req.the_request))
+            self.fail("strange req.the_request {0!s}".format(repr(req.the_request)))
 
         for x in ((req.assbackwards, "assbackwards"),
                   (req.proxyreq, "proxyreq"),
                   (req.header_only, "header_only")):
             val, name = x
-            log("    req.%s: %s" % (name, repr(val)))
+            log("    req.{0!s}: {1!s}".format(name, repr(val)))
             if val:
-                self.fail("%s should be 0" % name)
+                self.fail("{0!s} should be 0".format(name))
 
-        log("    req.protocol: %s" % repr(req.protocol))
+        log("    req.protocol: {0!s}".format(repr(req.protocol)))
         if not req.protocol == req.the_request.split()[-1]:
             self.fail("req.protocol doesn't match req.the_request")
 
-        log("    req.proto_num: %s" % repr(req.proto_num))
+        log("    req.proto_num: {0!s}".format(repr(req.proto_num)))
         if req.proto_num != 1000 + int(req.protocol[-1]):
             self.fail("req.proto_num doesn't match req.protocol")
 
-        log("    req.hostname: %s" % repr(req.hostname))
+        log("    req.hostname: {0!s}".format(repr(req.hostname)))
         if req.hostname != "test_internal":
             self.fail("req.hostname isn't 'test_internal'")
 
-        log("    req.request_time: %s" % repr(req.request_time))
+        log("    req.request_time: {0!s}".format(repr(req.request_time)))
         if (time.time() - req.request_time) > 10:
             self.fail("req.request_time suggests request started more than 10 secs ago")
 
-        log("    req.status_line: %s" % repr(req.status_line))
+        log("    req.status_line: {0!s}".format(repr(req.status_line)))
         if req.status_line:
             self.fail("req.status_line should be None at this point")
 
-        log("    req.status: %s" % repr(req.status))
+        log("    req.status: {0!s}".format(repr(req.status)))
         if req.status != 200:
             self.fail("req.status should be 200")
         req.status = req.status # make sure its writable
 
-        log("    req.method: %s" % repr(req.method))
+        log("    req.method: {0!s}".format(repr(req.method)))
         if req.method != "GET":
             self.fail("req.method should be 'GET'")
 
-        log("    req.method_number: %s" % repr(req.method_number))
+        log("    req.method_number: {0!s}".format(repr(req.method_number)))
         if req.method_number != 0:
             self.fail("req.method_number should be 0")
 
-        log("    req.allowed: %s" % repr(req.allowed))
+        log("    req.allowed: {0!s}".format(repr(req.allowed)))
         if req.allowed != 0:
             self.fail("req.allowed should be 0")
 
-        log("    req.allowed_xmethods: %s" % repr(req.allowed_xmethods))
+        log("    req.allowed_xmethods: {0!s}".format(repr(req.allowed_xmethods)))
         if req.allowed_xmethods != ():
             self.fail("req.allowed_xmethods should be an empty tuple")
 
-        log("    req.allowed_methods: %s" % repr(req.allowed_methods))
+        log("    req.allowed_methods: {0!s}".format(repr(req.allowed_methods)))
         if req.allowed_methods != ():
             self.fail("req.allowed_methods should be an empty tuple")
 
-        log("    req.sent_bodyct: %s" % repr(req.sent_bodyct))
+        log("    req.sent_bodyct: {0!s}".format(repr(req.sent_bodyct)))
         if req.sent_bodyct != 0:
             self.fail("req.sent_bodyct should be 0")
 
-        log("    req.bytes_sent: %s" % repr(req.bytes_sent))
+        log("    req.bytes_sent: {0!s}".format(repr(req.bytes_sent)))
         save = req.bytes_sent
         log("       writing 4 bytes...")
         req.write("1234")
-        log("       req.bytes_sent: %s" % repr(req.bytes_sent))
+        log("       req.bytes_sent: {0!s}".format(repr(req.bytes_sent)))
         if req.bytes_sent - save != 4:
             self.fail("req.bytes_sent should have incremented by 4, but didn't")
 
-        log("    req.mtime: %s" % repr(req.mtime))
+        log("    req.mtime: {0!s}".format(repr(req.mtime)))
         if req.mtime != 0:
             self.fail("req.mtime should be 0")
 
-        log("    req.chunked: %s" % repr(req.chunked))
+        log("    req.chunked: {0!s}".format(repr(req.chunked)))
         if req.chunked != 1:
             self.fail("req.chunked should be 1")
 
-        log("    req.range: %s" % repr(req.range))
+        log("    req.range: {0!s}".format(repr(req.range)))
         if req.range:
             self.fail("req.range should be None")
 
-        log("    req.clength: %s" % repr(req.clength))
+        log("    req.clength: {0!s}".format(repr(req.clength)))
         log("        calling req.set_content_length(15)...")
         req.set_content_length(15)
-        log("        req.clength: %s" % repr(req.clength))
+        log("        req.clength: {0!s}".format(repr(req.clength)))
         if req.clength != 15:
             self.fail("req.clength should be 15")
 
-        log("    req.remaining: %s" % repr(req.remaining))
+        log("    req.remaining: {0!s}".format(repr(req.remaining)))
         if req.remaining != 0:
             self.fail("req.remaining should be 0")
 
-        log("    req.read_length: %s" % repr(req.read_length))
+        log("    req.read_length: {0!s}".format(repr(req.read_length)))
         if req.read_length != 0:
             self.fail("req.read_length should be 0")
 
-        log("    req.read_body: %s" % repr(req.read_body))
+        log("    req.read_body: {0!s}".format(repr(req.read_body)))
         if req.read_body != 0:
             self.fail("req.read_body should be 0")
 
-        log("    req.read_chunked: %s" % repr(req.read_chunked))
+        log("    req.read_chunked: {0!s}".format(repr(req.read_chunked)))
         if req.read_chunked != 0:
             self.fail("req.read_chunked should be 0")
 
-        log("    req.expecting_100: %s" % repr(req.expecting_100))
+        log("    req.expecting_100: {0!s}".format(repr(req.expecting_100)))
         if req.expecting_100 != 0:
             self.fail("req.expecting_100 should be 0")
 
-        log("    req.headers_in: %s" % repr(req.headers_in))
+        log("    req.headers_in: {0!s}".format(repr(req.headers_in)))
         if req.headers_in["Host"][:13].lower() != "test_internal":
             self.fail("The 'Host' header should begin with 'test_internal'")
 
-        log("    req.headers_out: %s" % repr(req.headers_out))
+        log("    req.headers_out: {0!s}".format(repr(req.headers_out)))
         if (("content-length" not in req.headers_out) or
             req.headers_out["content-length"] != "15"):
             self.fail("req.headers_out['content-length'] should be 15")
 
-        log("    req.subprocess_env: %s" % repr(req.subprocess_env))
+        log("    req.subprocess_env: {0!s}".format(repr(req.subprocess_env)))
         if req.subprocess_env["SERVER_SOFTWARE"].find("Python") == -1:
             self.fail("req.subprocess_env['SERVER_SOFTWARE'] should contain 'Python'")
 
-        log("    req.notes: %s" % repr(req.notes))
+        log("    req.notes: {0!s}".format(repr(req.notes)))
         log("        doing req.notes['testing'] = '123' ...")
         req.notes['testing'] = '123'
-        log("    req.notes: %s" % repr(req.notes))
+        log("    req.notes: {0!s}".format(repr(req.notes)))
         if req.notes["testing"] != '123':
             self.fail("req.notes['testing'] should be '123'")
 
-        log("    req.phase: %s" % repr(req.phase))
+        log("    req.phase: {0!s}".format(repr(req.phase)))
         if req.phase != "PythonHandler":
             self.fail("req.phase should be 'PythonHandler'")
 
-        log("    req.interpreter: %s" % repr(req.interpreter))
+        log("    req.interpreter: {0!s}".format(repr(req.interpreter)))
         if req.interpreter != apache.interpreter:
-            self.fail("req.interpreter should be same as apache.interpreter" % repr(apache.interpreter))
+            self.fail("req.interpreter should be same as apache.interpreter".format(*repr(apache.interpreter)))
         if req.interpreter != req.server.server_hostname:
-            self.fail("req.interpreter should be same as req.server.server_hostname: %s" % repr(req.server.server_hostname))
+            self.fail("req.interpreter should be same as req.server.server_hostname: {0!s}".format(repr(req.server.server_hostname)))
 
-        log("    req.content_type: %s" % repr(req.content_type))
+        log("    req.content_type: {0!s}".format(repr(req.content_type)))
         log("        doing req.content_type = 'test/123' ...")
         req.content_type = 'test/123'
-        log("        req.content_type: %s" % repr(req.content_type))
+        log("        req.content_type: {0!s}".format(repr(req.content_type)))
         if req.content_type != 'test/123' or not req._content_type_set:
             self.fail("req.content_type should be 'test/123' and req._content_type_set 1")
 
-        log("    req.handler: %s" % repr(req.handler))
+        log("    req.handler: {0!s}".format(repr(req.handler)))
         if req.handler != "mod_python":
             self.fail("req.handler should be 'mod_python'")
 
-        log("    req.content_encoding: %s" % repr(req.content_encoding))
+        log("    req.content_encoding: {0!s}".format(repr(req.content_encoding)))
         if req.content_encoding:
             self.fail("req.content_encoding should be None")
 
-        log("    req.content_languages: %s" % repr(req.content_languages))
+        log("    req.content_languages: {0!s}".format(repr(req.content_languages)))
         if req.content_languages != ():
             self.fail("req.content_languages should be an empty tuple")
 
-        log("    req.vlist_validator: %s" % repr(req.vlist_validator))
+        log("    req.vlist_validator: {0!s}".format(repr(req.vlist_validator)))
         if req.vlist_validator:
             self.fail("req.vlist_validator should be None")
 
-        log("    req.user: %s" % repr(req.user))
+        log("    req.user: {0!s}".format(repr(req.user)))
         if req.user:
             self.fail("req.user should be None")
 
-        log("    req.ap_auth_type: %s" % repr(req.ap_auth_type))
+        log("    req.ap_auth_type: {0!s}".format(repr(req.ap_auth_type)))
         if req.ap_auth_type:
             self.fail("req.ap_auth_type should be None")
 
-        log("    req.no_cache: %s" % repr(req.no_cache))
+        log("    req.no_cache: {0!s}".format(repr(req.no_cache)))
         if req.no_cache != 0:
             self.fail("req.no_cache should be 0")
 
-        log("    req.no_local_copy: %s" % repr(req.no_local_copy))
+        log("    req.no_local_copy: {0!s}".format(repr(req.no_local_copy)))
         if req.no_local_copy != 0:
             self.fail("req.no_local_copy should be 0")
 
-        log("    req.unparsed_uri: %s" % repr(req.unparsed_uri))
+        log("    req.unparsed_uri: {0!s}".format(repr(req.unparsed_uri)))
         if req.unparsed_uri != "/tests.py":
             self.fail("req.unparsed_uri should be '/tests.py'")
 
-        log("    req.uri: %s" % repr(req.uri))
+        log("    req.uri: {0!s}".format(repr(req.uri)))
         if req.uri != "/tests.py":
             self.fail("req.uri should be '/tests.py'")
 
-        log("    req.filename: %s" % repr(req.filename))
+        log("    req.filename: {0!s}".format(repr(req.filename)))
         if req.filename != req.document_root() + req.uri:
             self.fail("req.filename should be req.document_root() + req.uri, but it isn't")
 
-        log("    req.canonical_filename: %s" % repr(req.canonical_filename))
+        log("    req.canonical_filename: {0!s}".format(repr(req.canonical_filename)))
         if not req.canonical_filename:
             self.fail("req.canonical_filename should not be blank")
 
-        log("    req.path_info: %s" % repr(req.path_info))
+        log("    req.path_info: {0!s}".format(repr(req.path_info)))
         if req.path_info != '':
             self.fail("req.path_info should be ''")
 
-        log("    req.args: %s" % repr(req.args))
+        log("    req.args: {0!s}".format(repr(req.args)))
         if req.args:
             self.fail("req.args should be None")
 
-        log("    req.finfo: %s" % repr(req.finfo))
+        log("    req.finfo: {0!s}".format(repr(req.finfo)))
         if req.finfo[apache.FINFO_FNAME] and (req.finfo[apache.FINFO_FNAME] != req.canonical_filename):
             self.fail("req.finfo[apache.FINFO_FNAME] should be the (canonical) filename")
 
-        log("    req.parsed_uri: %s" % repr(req.parsed_uri))
+        log("    req.parsed_uri: {0!s}".format(repr(req.parsed_uri)))
         if req.parsed_uri[apache.URI_PATH] != '/tests.py':
             self.fail("req.parsed_uri[apache.URI_PATH] should be '/tests.py'")
 
-        log("    req.used_path_info: %s" % repr(req.used_path_info))
+        log("    req.used_path_info: {0!s}".format(repr(req.used_path_info)))
         if req.used_path_info != 2:
             self.fail("req.used_path_info should be 2") # XXX really? :-)
 
-        log("    req.eos_sent: %s" % repr(req.eos_sent))
+        log("    req.eos_sent: {0!s}".format(repr(req.eos_sent)))
         if req.eos_sent:
             self.fail("req.eos_sent says we sent EOS, but we didn't")
 
@@ -381,11 +381,11 @@ class SimpleTestCase(unittest.TestCase):
             except:
                 localip = "127.0.0.1"
 
-            log("    req.useragent_ip: %s" % repr(req.useragent_ip))
+            log("    req.useragent_ip: {0!s}".format(repr(req.useragent_ip)))
             if not req.useragent_ip in ("127.0.0.1", localip):
                 self.fail("req.useragent_ip should be '127.0.0.1'")
 
-            log("    req.useragent_addr: %s" % repr(req.useragent_addr))
+            log("    req.useragent_addr: {0!s}".format(repr(req.useragent_addr)))
             if not req.useragent_addr[0] in ("127.0.0.1", "0.0.0.0", localip):
                 self.fail("req.useragent_addr[0] should be '127.0.0.1' or '0.0.0.0'")
 
@@ -395,24 +395,24 @@ class SimpleTestCase(unittest.TestCase):
         req = self.req
         log = req.log_error
 
-        log("req.get_config(): %s" % repr(req.get_config()))
+        log("req.get_config(): {0!s}".format(repr(req.get_config())))
         if req.get_config()["PythonDebug"] != "1":
             self.fail("get_config return should show PythonDebug 1")
 
-        log("req.get_options(): %s" % repr(req.get_options()))
+        log("req.get_options(): {0!s}".format(repr(req.get_options())))
         if req.get_options() != apache.table({"testing":"123"}):
-            self.fail("get_options() should contain 'testing':'123', contains %s"%list(req.get_options().items()))
+            self.fail("get_options() should contain 'testing':'123', contains {0!s}".format(list(req.get_options().items())))
 
     def test_req_get_remote_host(self):
 
         # simulating this test for real is too complex...
         req = self.req
         log = req.log_error
-        log("req.get_get_remote_host(): %s" % repr(req.get_remote_host(apache.REMOTE_HOST)))
-        log("req.get_get_remote_host(): %s" % repr(req.get_remote_host()))
+        log("req.get_get_remote_host(): {0!s}".format(repr(req.get_remote_host(apache.REMOTE_HOST))))
+        log("req.get_get_remote_host(): {0!s}".format(repr(req.get_remote_host())))
         if (req.get_remote_host(apache.REMOTE_HOST) != None) or \
            (req.get_remote_host() != "127.0.0.1"):
-            self.fail("remote host test failed: %s" % req.get_remote_host())
+            self.fail("remote host test failed: {0!s}".format(req.get_remote_host()))
 
     def test_server_members(self):
 
@@ -422,80 +422,80 @@ class SimpleTestCase(unittest.TestCase):
 
         log("Examining server memebers:")
 
-        log("    server.defn_name: %s" % repr(server.defn_name))
+        log("    server.defn_name: {0!s}".format(repr(server.defn_name)))
         if server.defn_name[-9:] != "test.conf":
             self.fail("server.defn_name does not end in 'test.conf'")
 
-        log("    server.defn_line_number: %s" % repr(server.defn_line_number))
+        log("    server.defn_line_number: {0!s}".format(repr(server.defn_line_number)))
         if server.defn_line_number == 0:
             self.fail("server.defn_line_number should not be 0")
 
-        log("    server.server_admin: %s" % repr(server.server_admin))
+        log("    server.server_admin: {0!s}".format(repr(server.server_admin)))
         if server.server_admin != "serveradmin@somewhere.com":
             self.fail("server.server_admin must be 'serveradmin@somewhere.com'")
 
-        log("    server.server_hostname: %s" % repr(server.server_hostname))
+        log("    server.server_hostname: {0!s}".format(repr(server.server_hostname)))
         if server.server_hostname != "test_internal":
             self.fail("server.server_hostname must be 'test_internal'")
 
-        log("    server.port: %s" % repr(server.port))
+        log("    server.port: {0!s}".format(repr(server.port)))
         # hmm it really is 0...
         #if server.port == 0:
         #    self.fail("server.port should not be 0")
 
-        log("    server.error_fname: %s" % repr(server.error_fname))
+        log("    server.error_fname: {0!s}".format(repr(server.error_fname)))
         if server.error_fname != "logs/error_log":
             self.fail("server.error_fname should be 'logs/error_log'")
 
-        log("    server.loglevel: %s" % repr(server.loglevel))
+        log("    server.loglevel: {0!s}".format(repr(server.loglevel)))
         if server.loglevel != 7:
             self.fail("server.loglevel should be 7")
 
-        log("    server.is_virtual: %s" % repr(server.is_virtual))
+        log("    server.is_virtual: {0!s}".format(repr(server.is_virtual)))
         if server.is_virtual != 1:
             self.fail("server.is_virtual should be 1")
 
-        log("    server.timeout: %s" % repr(server.timeout))
+        log("    server.timeout: {0!s}".format(repr(server.timeout)))
         if not server.timeout in (5.0, 60.0):
             self.fail("server.timeout should be 5.0 or 60.0")
 
-        log("    server.keep_alive_timeout: %s" % repr(server.keep_alive_timeout))
+        log("    server.keep_alive_timeout: {0!s}".format(repr(server.keep_alive_timeout)))
         if server.keep_alive_timeout != 15.0:
             self.fail("server.keep_alive_timeout should be 15.0")
 
-        log("    server.keep_alive_max: %s" % repr(server.keep_alive_max))
+        log("    server.keep_alive_max: {0!s}".format(repr(server.keep_alive_max)))
         if server.keep_alive_max != 100:
             self.fail("server.keep_alive_max should be 100")
 
-        log("    server.keep_alive: %s" % repr(server.keep_alive))
+        log("    server.keep_alive: {0!s}".format(repr(server.keep_alive)))
         if server.keep_alive != 1:
             self.fail("server.keep_alive should be 1")
 
-        log("    server.path: %s" % repr(server.path))
+        log("    server.path: {0!s}".format(repr(server.path)))
         if server.path != "some/path":
             self.fail("server.path should be 'some/path'")
 
-        log("    server.pathlen: %s" % repr(server.pathlen))
+        log("    server.pathlen: {0!s}".format(repr(server.pathlen)))
         if server.pathlen != len('some/path'):
-            self.fail("server.pathlen should be %d" % len('some/path'))
+            self.fail("server.pathlen should be {0:d}".format(len('some/path')))
 
-        log("    server.limit_req_line: %s" % repr(server.limit_req_line))
+        log("    server.limit_req_line: {0!s}".format(repr(server.limit_req_line)))
         if server.limit_req_line != 8190:
             self.fail("server.limit_req_line should be 8190")
 
-        log("    server.limit_req_fieldsize: %s" % repr(server.limit_req_fieldsize))
+        log("    server.limit_req_fieldsize: {0!s}".format(repr(server.limit_req_fieldsize)))
         if server.limit_req_fieldsize != 8190:
             self.fail("server.limit_req_fieldsize should be 8190")
 
-        log("    server.limit_req_fields: %s" % repr(server.limit_req_fields))
+        log("    server.limit_req_fields: {0!s}".format(repr(server.limit_req_fields)))
         if server.limit_req_fields != 100:
             self.fail("server.limit_req_fields should be 100")
 
-        log("    server.names: %s" % repr(server.names))
+        log("    server.names: {0!s}".format(repr(server.names)))
         if server.names != ():
             self.fail("server.names should be an empty tuple")
 
-        log("    server.wild_names: %s" % repr(server.wild_names))
+        log("    server.wild_names: {0!s}".format(repr(server.wild_names)))
         if server.wild_names != ():
             self.fail("server.wild_names should be an empty tuple")
 
@@ -514,71 +514,71 @@ class SimpleTestCase(unittest.TestCase):
 
         log("Examining connection memebers:")
 
-        log("    connection.base_server: %s" % repr(conn.base_server))
+        log("    connection.base_server: {0!s}".format(repr(conn.base_server)))
         if type(conn.base_server) is not type(req.server):
             self.fail("conn.base_server should be same type as req.server")
 
-        log("    connection.local_addr: %s" % repr(conn.local_addr))
+        log("    connection.local_addr: {0!s}".format(repr(conn.local_addr)))
         if not conn.local_addr[0] in ("127.0.0.1", "0.0.0.0", localip):
             self.fail("conn.local_addr[0] should be '127.0.0.1' or '0.0.0.0'")
 
         if apache.MODULE_MAGIC_NUMBER_MAJOR > 20111130:
 
-            log("    connection.client_addr: %s" % repr(conn.client_addr))
+            log("    connection.client_addr: {0!s}".format(repr(conn.client_addr)))
             if not conn.client_addr[0] in ("127.0.0.1", "0.0.0.0", localip):
                 self.fail("conn.client_addr[0] should be '127.0.0.1' or '0.0.0.0'")
 
-            log("    connection.client_ip: %s" % repr(conn.client_ip))
+            log("    connection.client_ip: {0!s}".format(repr(conn.client_ip)))
             if not conn.client_ip in ("127.0.0.1", localip):
                 self.fail("conn.client_ip should be '127.0.0.1'")
 
         else:
 
-            log("    connection.remote_addr: %s" % repr(conn.remote_addr))
+            log("    connection.remote_addr: {0!s}".format(repr(conn.remote_addr)))
             if not conn.remote_addr[0] in ("127.0.0.1", "0.0.0.0", localip):
                 self.fail("conn.remote_addr[0] should be '127.0.0.1' or '0.0.0.0'")
 
-            log("    connection.remote_ip: %s" % repr(conn.remote_ip))
+            log("    connection.remote_ip: {0!s}".format(repr(conn.remote_ip)))
             if not conn.remote_ip in ("127.0.0.1", localip):
                 self.fail("conn.remote_ip should be '127.0.0.1'")
 
-        log("    connection.remote_host: %s" % repr(conn.remote_host))
+        log("    connection.remote_host: {0!s}".format(repr(conn.remote_host)))
         if conn.remote_host is not None:
             self.fail("conn.remote_host should be None")
 
-        log("    connection.remote_logname: %s" % repr(conn.remote_logname))
+        log("    connection.remote_logname: {0!s}".format(repr(conn.remote_logname)))
         if conn.remote_logname is not None:
             self.fail("conn.remote_logname should be None")
 
-        log("    connection.aborted: %s" % repr(conn.aborted))
+        log("    connection.aborted: {0!s}".format(repr(conn.aborted)))
         if conn.aborted != 0:
             self.fail("conn.aborted should be 0")
 
-        log("    connection.keepalive: %s" % repr(conn.keepalive))
+        log("    connection.keepalive: {0!s}".format(repr(conn.keepalive)))
         if conn.keepalive != 2:
             self.fail("conn.keepalive should be 2")
 
-        log("    connection.double_reverse: %s" % repr(conn.double_reverse))
+        log("    connection.double_reverse: {0!s}".format(repr(conn.double_reverse)))
         if conn.double_reverse != 0:
             self.fail("conn.double_reverse should be 0")
 
-        log("    connection.keepalives: %s" % repr(conn.keepalives))
+        log("    connection.keepalives: {0!s}".format(repr(conn.keepalives)))
         if conn.keepalives != 1:
             self.fail("conn.keepalives should be 1")
 
-        log("    connection.local_ip: %s" % repr(conn.local_ip))
+        log("    connection.local_ip: {0!s}".format(repr(conn.local_ip)))
         if not conn.local_ip in ("127.0.0.1", localip):
             self.fail("conn.local_ip should be '127.0.0.1'")
 
-        log("    connection.local_host: %s" % repr(conn.local_host))
+        log("    connection.local_host: {0!s}".format(repr(conn.local_host)))
         if conn.local_host is not None:
             self.fail("conn.local_host should be None")
 
-        log("    connection.id: %s" % repr(conn.id))
+        log("    connection.id: {0!s}".format(repr(conn.id)))
         if conn.id > 10000:
             self.fail("conn.id probably should not be this high?")
 
-        log("    connection.notes: %s" % repr(conn.notes))
+        log("    connection.notes: {0!s}".format(repr(conn.notes)))
         if repr(conn.notes) != '{}':
             self.fail("conn.notes should be {}")
 
@@ -654,9 +654,9 @@ def req_add_empty_handler_string(req):
 
 def req_add_handler_empty_phase(req):
     req.log_error("req_add_handler_empty_phase")
-    req.log_error("phase=%s" % req.phase)
-    req.log_error("interpreter=%s" % req.interpreter)
-    req.log_error("directory=%s" % req.hlist.directory)
+    req.log_error("phase={0!s}".format(req.phase))
+    req.log_error("interpreter={0!s}".format(req.interpreter))
+    req.log_error("directory={0!s}".format(req.hlist.directory))
     if req.phase != "PythonHandler":
         directory = os.path.dirname(__file__)
         req.add_handler("PythonHandler", "tests::req_add_handler_empty_phase", directory)
@@ -716,7 +716,7 @@ def req_get_basic_auth_pw(req):
         req.user == LATIN1_SPAM and pw == LATIN1_EGGS):
         req.write("test ok")
     else:
-        req.write("test failed, user %s, pw %s" % (repr(req.user), repr(pw)))
+        req.write("test failed, user {0!s}, pw {1!s}".format(repr(req.user), repr(pw)))
 
     return apache.OK
 
@@ -734,12 +734,12 @@ def req_auth_type(req):
     auth_type = req.auth_type()
     if auth_type != "dummy":
         req.log_error("auth_type check failed")
-        req.write("test failed, req.auth_type() returned: %s" % repr(auth_type))
+        req.write("test failed, req.auth_type() returned: {0!s}".format(repr(auth_type)))
         return apache.DONE
     auth_name = req.auth_name()
     if auth_name != "blah":
         req.log_error("auth_name check failed")
-        req.write("test failed, req.auth_name() returned: %s" % repr(auth_name))
+        req.write("test failed, req.auth_name() returned: {0!s}".format(repr(auth_name)))
         return apache.DONE
 
     if req.phase == "PythonAuthenHandler":
@@ -824,18 +824,18 @@ def req_discard_request_body(req):
 
     s = req.read(10)
     if s != b'1234567890':
-        req.log_error('read() #1 returned %s' % repr(s))
+        req.log_error('read() #1 returned {0!s}'.format(repr(s)))
         req.write('test failed')
         return apache.OK
 
     status = req.discard_request_body()
     if status != apache.OK:
-        req.log_error('discard_request_body() returned %d' % status)
+        req.log_error('discard_request_body() returned {0:d}'.format(status))
         return status
 
     s = req.read()
     if s:
-        req.log_error('read() #2 returned %s' % repr(s))
+        req.log_error('read() #2 returned {0!s}'.format(repr(s)))
         req.write('test failed')
         return apache.OK
 
@@ -909,7 +909,7 @@ def req_sendfile3(req):
     f = open(fname, "w")
     f.write("0123456789"*100);
     f.close()
-    fname_symlink =  '%s.lnk' % fname
+    fname_symlink =  '{0!s}.lnk'.format(fname)
     os.symlink(fname, fname_symlink)
     req.sendfile(fname_symlink)
     os.remove(fname_symlink)
@@ -1044,17 +1044,17 @@ def postreadrequest(req):
     req.subprocess_env['TEST1'] = "'"
     req.subprocess_env['TEST2'] = '"'
 
-    req.log_error('subprocess_env = %s' % req.subprocess_env)
-    req.log_error('subprocess_env.values() = %s' % list(req.subprocess_env.values()))
+    req.log_error('subprocess_env = {0!s}'.format(req.subprocess_env))
+    req.log_error('subprocess_env.values() = {0!s}'.format(list(req.subprocess_env.values())))
 
     for value in req.subprocess_env.values():
-        req.log_error('VALUE = %s' % value)
+        req.log_error('VALUE = {0!s}'.format(value))
 
     for item in req.subprocess_env.items():
-        req.log_error('ITEM = %s' % (item,))
+        req.log_error('ITEM = {0!s}'.format(item))
 
-    req.log_error('SCRIPT_FILENAME = %s' % req.subprocess_env.get('SCRIPT_FILENAME'))
-    req.log_error('SCRIPT_FILENAME = %s' % req.subprocess_env['SCRIPT_FILENAME'])
+    req.log_error('SCRIPT_FILENAME = {0!s}'.format(req.subprocess_env.get('SCRIPT_FILENAME')))
+    req.log_error('SCRIPT_FILENAME = {0!s}'.format(req.subprocess_env['SCRIPT_FILENAME']))
 
     req.write("test ok")
 
@@ -1254,7 +1254,7 @@ def phase_status_7(req):
 
 def phase_status_8(req):
     apache.log_error("phase_status_8")
-    apache.log_error("phases = %s" % req.phases)
+    apache.log_error("phases = {0!s}".format(req.phases))
     if req.phases != [1, 2, 5, 6, 7]:
         req.write("test failed")
     else:
@@ -1287,10 +1287,10 @@ def interpreter(req):
     return apache.DONE
 
 def index(req):
-    return "test ok, interpreter=%s" % req.interpreter
+    return "test ok, interpreter={0!s}".format(req.interpreter)
 
 def test_publisher(req):
-    return "test ok, interpreter=%s" % req.interpreter
+    return "test ok, interpreter={0!s}".format(req.interpreter)
 
 def test_publisher_auth_nested(req):
     def __auth__(req, user, password):
@@ -1302,7 +1302,7 @@ def test_publisher_auth_nested(req):
         return 1
     assert(int(req.notes.get("auth_called",0)))
     assert(int(req.notes.get("access_called",0)))
-    return "test ok, interpreter=%s" % req.interpreter
+    return "test ok, interpreter={0!s}".format(req.interpreter)
 
 class _test_publisher_auth_method_nested:
     def method(self, req):
@@ -1315,7 +1315,7 @@ class _test_publisher_auth_method_nested:
             return 1
         assert(int(req.notes.get("auth_called",0)))
         assert(int(req.notes.get("access_called",0)))
-        return "test ok, interpreter=%s" % req.interpreter
+        return "test ok, interpreter={0!s}".format(req.interpreter)
 
 test_publisher_auth_method_nested = _test_publisher_auth_method_nested()
 
@@ -1357,7 +1357,7 @@ class Mapping(object):
         self.name = name
 
     def __call__(self,req):
-        return "Called %s"%self.name
+        return "Called {0!s}".format(self.name)
 hierarchy_root = Mapping("root");
 hierarchy_root.page1 = Mapping("page1")
 hierarchy_root.page1.subpage1 = Mapping("subpage1")
@@ -1521,14 +1521,14 @@ def _test_table():
                 b = a.copy()
             for i in range(size):
                 ka, va = ta = a.popitem()
-                if va != ka: raise TestFailed("a.popitem: %s" % str(ta))
+                if va != ka: raise TestFailed("a.popitem: {0!s}".format(str(ta)))
                 kb, vb = tb = b.popitem()
-                if vb != kb: raise TestFailed("b.popitem: %s" % str(tb))
+                if vb != kb: raise TestFailed("b.popitem: {0!s}".format(str(tb)))
                 if copymode < 0 and ta != tb:
-                    raise TestFailed("a.popitem != b.popitem: %s, %s" % (
+                    raise TestFailed("a.popitem != b.popitem: {0!s}, {1!s}".format(
                         str(ta), str(tb)))
-            if a: raise TestFailed('a not empty after popitems: %s' % str(a))
-            if b: raise TestFailed('b not empty after popitems: %s' % str(b))
+            if a: raise TestFailed('a not empty after popitems: {0!s}'.format(str(a)))
+            if b: raise TestFailed('b not empty after popitems: {0!s}'.format(str(b)))
 
     # iteration (just make sure we can iterate without a segfault)
     d = apache.table({'a' : '1', 'b' : '2', 'c' : '3'})
@@ -1560,6 +1560,6 @@ def memory(req):
     ## check memory usage after
     after = list(map(int, open("/proc/self/statm").read().split()))
 
-    req.write("|%s|%s" % (before[0], after[0]))
+    req.write("|{0!s}|{1!s}".format(before[0], after[0]))
 
     return apache.OK

--- a/test/test.py
+++ b/test/test.py
@@ -138,7 +138,7 @@ else:
         else:
             if os.path.isdir(value):
                 return True
-        print('Bad value for mod_python.version.%s : %s'%(
+        print('Bad value for mod_python.version.{0!s} : {1!s}'.format(
             variable,
             value
         ))
@@ -249,7 +249,7 @@ def get_apache_version():
 
     print("Checking Apache version....")
     httpd = quote_if_space(HTTPD)
-    stdout = getoutput('%s -v' % (httpd))
+    stdout = getoutput('{0!s} -v'.format((httpd)))
 
     version_str = None
     for line in stdout.splitlines():
@@ -260,7 +260,7 @@ def get_apache_version():
     if version_str:
         version_str = version_str.split('/')[1]
         major,minor,patch = version_str.split('.',3)
-        version = '%s.%s' % (major,minor)
+        version = '{0!s}.{1!s}'.format(major, minor)
     else:
 
         print("Can't determine Apache version. Assuming 2.0")
@@ -270,8 +270,7 @@ def get_apache_version():
 
 APACHE_VERSION = get_apache_version()
 if not mod_python.version.HTTPD_VERSION.startswith(APACHE_VERSION):
-    print("ERROR: Build version %s does not match version reported by %s: %s, re-run ./configure?" % \
-        (mod_python.version.HTTPD_VERSION, HTTPD, APACHE_VERSION))
+    print("ERROR: Build version {0!s} does not match version reported by {1!s}: {2!s}, re-run ./configure?".format(mod_python.version.HTTPD_VERSION, HTTPD, APACHE_VERSION))
     sys.exit()
 
 class HttpdCtrl:
@@ -335,17 +334,17 @@ class HttpdCtrl:
                      ThreadsPerChild("5"),
                      MaxRequestsPerChild("0")),
             IfModule("!mod_mime.c",
-                     LoadModule("mime_module %s" %
-                                quote_if_space(os.path.join(modpath, "mod_mime.so")))),
+                     LoadModule("mime_module {0!s}".format(
+                                quote_if_space(os.path.join(modpath, "mod_mime.so"))))),
             IfModule("!mod_log_config.c",
-                     LoadModule("log_config_module %s" %
-                                quote_if_space(os.path.join(modpath, "mod_log_config.so")))),
+                     LoadModule("log_config_module {0!s}".format(
+                                quote_if_space(os.path.join(modpath, "mod_log_config.so"))))),
             IfModule("!mod_dir.c",
-                     LoadModule("dir_module %s" %
-                                quote_if_space(os.path.join(modpath, "mod_dir.so")))),
+                     LoadModule("dir_module {0!s}".format(
+                                quote_if_space(os.path.join(modpath, "mod_dir.so"))))),
             IfModule("!mod_include.c",
-                     LoadModule("include_module %s" %
-                                quote_if_space(os.path.join(modpath, "mod_include.so")))),
+                     LoadModule("include_module {0!s}".format(
+                                quote_if_space(os.path.join(modpath, "mod_include.so"))))),
             ServerRoot(SERVER_ROOT),
             ErrorLog("logs/error_log"),
             LogLevel("debug"),
@@ -356,10 +355,10 @@ class HttpdCtrl:
             ServerName("127.0.0.1"),
             Listen(PORT),
             Timeout(60),
-            PythonOption('mod_python.mutex_directory %s' % TMP_DIR),
+            PythonOption('mod_python.mutex_directory {0!s}'.format(TMP_DIR)),
             PythonOption('PythonOptionTest sample_value'),
             DocumentRoot(DOCUMENT_ROOT),
-            LoadModule("python_module %s" % quote_if_space(MOD_PYTHON_SO)))
+            LoadModule("python_module {0!s}".format(quote_if_space(MOD_PYTHON_SO))))
 
         if APACHE_VERSION == '2.4':
             s.append(Mutex("file:logs"))
@@ -368,34 +367,34 @@ class HttpdCtrl:
 
         if APACHE_VERSION == '2.4':
             s.append(IfModule("!mod_unixd.c",
-                              LoadModule("unixd_module %s" %
-                                         quote_if_space(os.path.join(modpath, "mod_unixd.so")))))
+                              LoadModule("unixd_module {0!s}".format(
+                                         quote_if_space(os.path.join(modpath, "mod_unixd.so"))))))
             s.append(IfModule("!mod_authn_core.c",
-                              LoadModule("authn_core_module %s" %
-                                         quote_if_space(os.path.join(modpath, "mod_authn_core.so")))))
+                              LoadModule("authn_core_module {0!s}".format(
+                                         quote_if_space(os.path.join(modpath, "mod_authn_core.so"))))))
             s.append(IfModule("!mod_authz_core.c",
-                              LoadModule("authz_core_module %s" %
-                                         quote_if_space(os.path.join(modpath, "mod_authz_core.so")))))
+                              LoadModule("authz_core_module {0!s}".format(
+                                         quote_if_space(os.path.join(modpath, "mod_authz_core.so"))))))
             s.append(IfModule("!mod_authn_file.c",
-                              LoadModule("authn_file_module %s" %
-                                         quote_if_space(os.path.join(modpath, "mod_authn_file.so")))))
+                              LoadModule("authn_file_module {0!s}".format(
+                                         quote_if_space(os.path.join(modpath, "mod_authn_file.so"))))))
             s.append(IfModule("!mod_authz_user.c",
-                              LoadModule("authz_user_module %s" %
-                                         quote_if_space(os.path.join(modpath, "mod_authz_user.so")))))
+                              LoadModule("authz_user_module {0!s}".format(
+                                         quote_if_space(os.path.join(modpath, "mod_authz_user.so"))))))
 
         if APACHE_VERSION in ['2.2', '2.4']:
             # mod_auth has been split into mod_auth_basic and some other modules
             s.append(IfModule("!mod_auth_basic.c",
-                     LoadModule("auth_basic_module %s" %
-                                quote_if_space(os.path.join(modpath, "mod_auth_basic.so")))))
+                     LoadModule("auth_basic_module {0!s}".format(
+                                quote_if_space(os.path.join(modpath, "mod_auth_basic.so"))))))
 
             # Default KeepAliveTimeout is 5 for apache 2.2, but 15 in apache 2.0
             # Explicitly set the value so it's the same as 2.0
             s.append(KeepAliveTimeout("15"))
         else:
             s.append(IfModule("!mod_auth.c",
-                     LoadModule("auth_module %s" %
-                                quote_if_space(os.path.join(modpath, "mod_auth.so")))))
+                     LoadModule("auth_module {0!s}".format(
+                                quote_if_space(os.path.join(modpath, "mod_auth.so"))))))
 
 
         s.append(Comment(" --APPENDED--"))
@@ -410,7 +409,7 @@ class HttpdCtrl:
         print("  Starting Apache....")
         httpd = quote_if_space(HTTPD)
         config = quote_if_space(CONFIG)
-        cmd = '%s %s -k start -f %s' % (httpd, extra, config)
+        cmd = '{0!s} {1!s} -k start -f {2!s}'.format(httpd, extra, config)
         print("    ", cmd)
         os.system(cmd)
         time.sleep(1)
@@ -421,7 +420,7 @@ class HttpdCtrl:
         print("  Stopping Apache...")
         httpd = quote_if_space(HTTPD)
         config = quote_if_space(CONFIG)
-        cmd = '%s -k stop -f %s' % (httpd, config)
+        cmd = '{0!s} -k stop -f {1!s}'.format(httpd, config)
         print("    ", cmd)
         os.system(cmd)
         time.sleep(1)
@@ -460,13 +459,13 @@ class PerRequestTestCase(unittest.TestCase):
     def vhost_get(self, vhost, path="/tests.py"):
 
         # this is so that tests could easily be staged with curl
-        curl = "curl --verbose --header 'Host: %s' http://127.0.0.1:%s%s" % (vhost, PORT, path)
-        print("    $ %s" % curl)
+        curl = "curl --verbose --header 'Host: {0!s}' http://127.0.0.1:{1!s}{2!s}".format(vhost, PORT, path)
+        print("    $ {0!s}".format(curl))
 
         # allows to specify a custom host: header
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", path, skip_host=1)
-        conn.putheader("Host", "%s:%s" % (vhost, PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format(vhost, PORT))
         conn.endheaders()
         response = conn.getresponse()
         if PY2:
@@ -496,7 +495,7 @@ class PerRequestTestCase(unittest.TestCase):
             entity.write(boundary)
             entity.write('\r\n')
             entity.write('Content-Type: text/plain\r\n')
-            entity.write('Content-Disposition: form-data;\r\n name="%s"\r\n' % name)
+            entity.write('Content-Disposition: form-data;\r\n name="{0!s}"\r\n'.format(name))
             entity.write('\r\n')
             entity.write(str(value))
             entity.write('\r\n')
@@ -517,7 +516,7 @@ class PerRequestTestCase(unittest.TestCase):
             entity.write(boundary)
             entity.write('\r\n')
             entity.write('Content-Type: application/octet-stream\r\n')
-            entity.write('Content-Disposition: form-data; name="%s"; filename="%s"\r\n' % (name, filename))
+            entity.write('Content-Disposition: form-data; name="{0!s}"; filename="{1!s}"\r\n'.format(name, filename))
             entity.write('\r\n')
             entity.write(content)
             entity.write('\r\n')
@@ -533,12 +532,12 @@ class PerRequestTestCase(unittest.TestCase):
         else:
             entity = bio.getvalue()
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         #conn.set_debuglevel(1000)
         conn.putrequest("POST", path, skip_host=1)
-        conn.putheader("Host", "%s:%s" % (vhost, PORT))
-        conn.putheader("Content-Type", 'multipart/form-data; boundary="%s"' % boundary)
-        conn.putheader("Content-Length", '%s'%(len(entity)))
+        conn.putheader("Host", "{0!s}:{1!s}".format(vhost, PORT))
+        conn.putheader("Content-Type", 'multipart/form-data; boundary="{0!s}"'.format(boundary))
+        conn.putheader("Content-Length", '{0!s}'.format((len(entity))))
         conn.endheaders()
 
         start = time.time()
@@ -546,7 +545,7 @@ class PerRequestTestCase(unittest.TestCase):
         response = conn.getresponse()
         rsp = response.read()
         conn.close()
-        print('    --> Send + process + receive took %.3f s'%(time.time()-start))
+        print('    --> Send + process + receive took {0:.3f} s'.format((time.time()-start)))
 
         return rsp
 
@@ -720,9 +719,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.allow_methods()")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_allow_methods", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_allow_methods", PORT))
         conn.endheaders()
         response = conn.getresponse()
         server_hdr = response.getheader("Allow", "")
@@ -760,14 +759,14 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing whether returning HTTP_UNAUTHORIZED works")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_unauthorized", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_unauthorized", PORT))
         auth = base64.encodestring(b"spam:eggs").strip()
         if PY2:
-            conn.putheader("Authorization", "Basic %s" % auth)
+            conn.putheader("Authorization", "Basic {0!s}".format(auth))
         else:
-            conn.putheader("Authorization", "Basic %s" % auth.decode("latin1"))
+            conn.putheader("Authorization", "Basic {0!s}".format(auth.decode("latin1")))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -776,21 +775,21 @@ class PerRequestTestCase(unittest.TestCase):
         if (rsp != b"test ok"):
             self.fail(repr(rsp))
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_unauthorized", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_unauthorized", PORT))
         auth = base64.encodestring(b"spam:BAD PASSWD").strip()
         if PY2:
-            conn.putheader("Authorization", "Basic %s" % auth)
+            conn.putheader("Authorization", "Basic {0!s}".format(auth))
         else:
-            conn.putheader("Authorization", "Basic %s" % auth.decode("latin1"))
+            conn.putheader("Authorization", "Basic {0!s}".format(auth.decode("latin1")))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
         conn.close()
 
         if response.status != UNAUTHORIZED:
-            self.fail("req.status is not httplib.UNAUTHORIZED, but: %s" % repr(response.status))
+            self.fail("req.status is not httplib.UNAUTHORIZED, but: {0!s}".format(repr(response.status)))
 
         if rsp == b"test ok":
             self.fail("We were supposed to get HTTP_UNAUTHORIZED")
@@ -825,14 +824,14 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.get_basic_auth_pw()")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_get_basic_auth_pw", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_get_basic_auth_pw", PORT))
         auth = base64.encodestring(b"spam:eggs").strip()
         if PY2:
-            conn.putheader("Authorization", "Basic %s" % auth)
+            conn.putheader("Authorization", "Basic {0!s}".format(auth))
         else:
-            conn.putheader("Authorization", "Basic %s" % auth.decode("latin1"))
+            conn.putheader("Authorization", "Basic {0!s}".format(auth.decode("latin1")))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -848,14 +847,14 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.get_basic_auth_pw_latin1()")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_get_basic_auth_pw", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_get_basic_auth_pw", PORT))
         auth = base64.encodestring(b'sp\xe1m:\xe9ggs').strip()
         if PY2:
-            conn.putheader("Authorization", "Basic %s" % auth)
+            conn.putheader("Authorization", "Basic {0!s}".format(auth))
         else:
-            conn.putheader("Authorization", "Basic %s" % auth.decode("latin1"))
+            conn.putheader("Authorization", "Basic {0!s}".format(auth.decode("latin1")))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -884,9 +883,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.auth_type()")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_auth_type", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_auth_type", PORT))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -916,14 +915,14 @@ class PerRequestTestCase(unittest.TestCase):
 
         rsp = self.vhost_get("test_req_requires")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_requires", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_requires", PORT))
         auth = base64.encodestring(b"spam:eggs").strip()
         if PY2:
-            conn.putheader("Authorization", "Basic %s" % auth)
+            conn.putheader("Authorization", "Basic {0!s}".format(auth))
         else:
-            conn.putheader("Authorization", "Basic %s" % auth.decode("latin1"))
+            conn.putheader("Authorization", "Basic {0!s}".format(auth.decode("latin1")))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -988,10 +987,10 @@ class PerRequestTestCase(unittest.TestCase):
         print("\n  * Testing req.read()")
 
         params = b'1234567890'*10000
-        print("    writing %d bytes..." % len(params))
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        print("    writing {0:d} bytes...".format(len(params)))
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("POST", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_req_read:%s" % PORT)
+        conn.putheader("Host", "test_req_read:{0!s}".format(PORT))
         conn.putheader("Content-Length", str(len(params)))
         conn.endheaders()
         conn.send(params)
@@ -999,14 +998,14 @@ class PerRequestTestCase(unittest.TestCase):
         rsp = response.read()
         conn.close()
 
-        print("    response size: %d\n" % len(rsp))
+        print("    response size: {0:d}\n".format(len(rsp)))
         if (rsp != params):
             self.fail(repr(rsp))
 
         print("    read/write ok, now lets try causing a timeout (should be 5 secs)")
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("POST", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_req_read:%s" % PORT)
+        conn.putheader("Host", "test_req_read:{0!s}".format(PORT))
         conn.putheader("Content-Length", str(10))
         conn.endheaders()
         conn.send(b"123456789")
@@ -1034,10 +1033,10 @@ class PerRequestTestCase(unittest.TestCase):
         print("\n  * Testing req.readline()")
 
         params = (b'1234567890'*3000+b'\n')*4
-        print("    writing %d bytes..." % len(params))
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        print("    writing {0:d} bytes...".format(len(params)))
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("POST", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_req_readline:%s" % PORT)
+        conn.putheader("Host", "test_req_readline:{0!s}".format(PORT))
         conn.putheader("Content-Length", str(len(params)))
         conn.endheaders()
         conn.send(params)
@@ -1045,7 +1044,7 @@ class PerRequestTestCase(unittest.TestCase):
         rsp = response.read()
         conn.close()
 
-        print("    response size: %d\n" % len(rsp))
+        print("    response size: {0:d}\n".format(len(rsp)))
         if (rsp != params):
             self.fail(repr(rsp))
 
@@ -1065,10 +1064,10 @@ class PerRequestTestCase(unittest.TestCase):
         print("\n  * Testing req.readlines()")
 
         params = (b'1234567890'*3000+b'\n')*4
-        print("    writing %d bytes..." % len(params))
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        print("    writing {0:d} bytes...".format(len(params)))
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("POST", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_req_readlines:%s" % PORT)
+        conn.putheader("Host", "test_req_readlines:{0!s}".format(PORT))
         conn.putheader("Content-Length", str(len(params)))
         conn.endheaders()
         conn.send(params)
@@ -1076,17 +1075,17 @@ class PerRequestTestCase(unittest.TestCase):
         rsp = response.read()
         conn.close()
 
-        print("    response size: %d\n" % len(rsp))
+        print("    response size: {0:d}\n".format(len(rsp)))
         if (rsp != params):
             self.fail(repr(rsp))
 
         print("\n  * Testing req.readlines(size_hint=30000)")
 
         params = (b'1234567890'*3000+b'\n')*4
-        print("    writing %d bytes..." % len(params))
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        print("    writing {0:d} bytes...".format(len(params)))
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("POST", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_req_readlines:%s" % PORT)
+        conn.putheader("Host", "test_req_readlines:{0!s}".format(PORT))
         conn.putheader("Content-Length", str(len(params)))
         conn.putheader("SizeHint", str(30000))
         conn.endheaders()
@@ -1095,17 +1094,17 @@ class PerRequestTestCase(unittest.TestCase):
         rsp = response.read()
         conn.close()
 
-        print("    response size: %d\n" % len(rsp))
+        print("    response size: {0:d}\n".format(len(rsp)))
         if (rsp != (b'1234567890'*3000+b'\n')):
             self.fail(repr(rsp))
 
         print("\n  * Testing req.readlines(size_hint=32000)")
 
         params = (b'1234567890'*3000+b'\n')*4
-        print("    writing %d bytes..." % len(params))
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        print("    writing {0:d} bytes...".format(len(params)))
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("POST", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_req_readlines:%s" % PORT)
+        conn.putheader("Host", "test_req_readlines:{0!s}".format(PORT))
         conn.putheader("Content-Length", str(len(params)))
         conn.putheader("SizeHint", str(32000))
         conn.endheaders()
@@ -1114,7 +1113,7 @@ class PerRequestTestCase(unittest.TestCase):
         rsp = response.read()
         conn.close()
 
-        print("    response size: %d\n" % len(rsp))
+        print("    response size: {0:d}\n".format(len(rsp)))
         if (rsp != ((b'1234567890'*3000+b'\n')*2)):
             self.fail(repr(rsp))
 
@@ -1135,10 +1134,10 @@ class PerRequestTestCase(unittest.TestCase):
         print("\n  * Testing req.discard_request_body()")
 
         params = b'1234567890'*2
-        print("    writing %d bytes..." % len(params))
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        print("    writing {0:d} bytes...".format(len(params)))
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_req_discard_request_body:%s" % PORT)
+        conn.putheader("Host", "test_req_discard_request_body:{0!s}".format(PORT))
         conn.putheader("Content-Length", str(len(params)))
         conn.endheaders()
         conn.send(params)
@@ -1189,9 +1188,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.headers_out")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/test.py", skip_host=1)
-        conn.putheader("Host", "test_req_headers_out:%s" % PORT)
+        conn.putheader("Host", "test_req_headers_out:{0!s}".format(PORT))
         conn.endheaders()
         response = conn.getresponse()
         h = response.getheader("x-test-header", None)
@@ -1285,9 +1284,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.handler")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_handler", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_handler", PORT))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -1311,9 +1310,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.no_cache")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_no_cache", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_no_cache", PORT))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -1340,9 +1339,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing req.update_mtime")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_req_update_mtime", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_req_update_mtime", PORT))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -1372,16 +1371,16 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing util.redirect()")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_util_redirect", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_util_redirect", PORT))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
         conn.close()
 
         if response.status != 302:
-            self.fail('did not receive 302 status response: %s' % repr(response.status))
+            self.fail('did not receive 302 status response: {0!s}'.format(repr(response.status)))
 
         if response.getheader("location", None) != "/dummy":
             self.fail('did not receive correct location for redirection')
@@ -1459,7 +1458,7 @@ class PerRequestTestCase(unittest.TestCase):
         )
 
         if (rsp != digest):
-            self.fail('1 MB file upload failed, its contents were corrupted. Expected (%s), got (%s)' % (repr(digest), repr(rsp)))
+            self.fail('1 MB file upload failed, its contents were corrupted. Expected ({0!s}), got ({1!s})'.format(repr(digest), repr(rsp)))
 
     def test_fileupload_embedded_cr_conf(self):
 
@@ -1495,7 +1494,7 @@ class PerRequestTestCase(unittest.TestCase):
         )
 
         if (rsp != digest):
-            self.fail('file upload embedded \\r test failed, its contents were corrupted (%s)'%rsp)
+            self.fail('file upload embedded \\r test failed, its contents were corrupted ({0!s})'.format(rsp))
 
         # The UNIX-HATERS handbook illustrates this problem. Once we've done some additional
         # investigation to make sure that our synthetic file used above is correct,
@@ -1524,7 +1523,7 @@ class PerRequestTestCase(unittest.TestCase):
 
 
             if (rsp != digest):
-                self.fail('The UNIX-HATERS handbook file upload failed, its contents was corrupted (%s)'%rsp)
+                self.fail('The UNIX-HATERS handbook file upload failed, its contents was corrupted ({0!s})'.format(rsp))
 
     def test_fileupload_split_boundary_conf(self):
 
@@ -1565,7 +1564,7 @@ class PerRequestTestCase(unittest.TestCase):
         )
 
         if (rsp != digest):
-            self.fail('file upload long line test failed, its contents were corrupted (%s)'%rsp)
+            self.fail('file upload long line test failed, its contents were corrupted ({0!s})'.format(rsp))
 
         print("  * Testing file upload where length of last line == readBlockSize - 1 with an extra \\r")
 
@@ -1583,7 +1582,7 @@ class PerRequestTestCase(unittest.TestCase):
         )
 
         if (rsp != digest):
-            self.fail('file upload long line test failed, its contents were corrupted (%s)'%rsp)
+            self.fail('file upload long line test failed, its contents were corrupted ({0!s})'.format(rsp))
 
     def test_sys_argv_conf(self):
 
@@ -1783,7 +1782,7 @@ class PerRequestTestCase(unittest.TestCase):
         headers = {"Host": "test_util_fieldstorage",
                    "Content-type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.request("POST", "/tests.py", params, headers)
         response = conn.getresponse()
         rsp = response.read()
@@ -1799,7 +1798,7 @@ class PerRequestTestCase(unittest.TestCase):
                         ServerName("test_postreadrequest"),
                         DocumentRoot(DOCUMENT_ROOT),
                         SetHandler("mod_python"),
-                        PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+                        PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                         PythonPostReadRequestHandler("tests::postreadrequest"),
                         PythonDebug("On"))
         return c
@@ -1818,7 +1817,7 @@ class PerRequestTestCase(unittest.TestCase):
                         ServerName("test_trans"),
                         DocumentRoot(DOCUMENT_ROOT),
                         SetHandler("mod_python"),
-                        PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+                        PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                         PythonTransHandler("tests::trans"),
                         PythonDebug("On"))
         return c
@@ -1834,7 +1833,7 @@ class PerRequestTestCase(unittest.TestCase):
     def test_import_conf(self):
 
         # configure apache to import it at startup
-        c = Container(PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+        c = Container(PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                       PythonImport("dummymodule test_import"),
                       PythonImport("dummymodule::function test_import"),
                       VirtualHost("*",
@@ -1860,7 +1859,7 @@ class PerRequestTestCase(unittest.TestCase):
                         ServerName("test_outputfilter"),
                         DocumentRoot(DOCUMENT_ROOT),
                         SetHandler("mod_python"),
-                        PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+                        PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                         PythonHandler("tests::simplehandler"),
                         PythonOutputFilter("tests::outputfilter MP_TEST_FILTER"),
                         PythonDebug("On"),
@@ -1881,7 +1880,7 @@ class PerRequestTestCase(unittest.TestCase):
                         ServerName("test_req_add_output_filter"),
                         DocumentRoot(DOCUMENT_ROOT),
                         SetHandler("mod_python"),
-                        PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+                        PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                         PythonHandler("tests::req_add_output_filter"),
                         PythonOutputFilter("tests::outputfilter MP_TEST_FILTER"),
                         PythonDebug("On"))
@@ -1901,7 +1900,7 @@ class PerRequestTestCase(unittest.TestCase):
                         ServerName("test_req_register_output_filter"),
                         DocumentRoot(DOCUMENT_ROOT),
                         SetHandler("mod_python"),
-                        PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+                        PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                         PythonHandler("tests::req_register_output_filter"),
                         PythonDebug("On"))
         return c
@@ -1922,18 +1921,18 @@ class PerRequestTestCase(unittest.TestCase):
             localip = "127.0.0.1"
 
         self.conport = findUnusedPort()
-        c = Container(Listen("%d" % self.conport),
-                      VirtualHost("%s:%d" % (localip, self.conport),
+        c = Container(Listen("{0:d}".format(self.conport)),
+                      VirtualHost("{0!s}:{1:d}".format(localip, self.conport),
                                   SetHandler("mod_python"),
-                                  PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+                                  PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                                   PythonConnectionHandler("tests::connectionhandler")))
         return c
 
     def test_connectionhandler(self):
 
-        print("\n  * Testing PythonConnectionHandler on port %d" % self.conport)
+        print("\n  * Testing PythonConnectionHandler on port {0:d}".format(self.conport))
 
-        url = "http://127.0.0.1:%s/tests.py" % self.conport
+        url = "http://127.0.0.1:{0!s}/tests.py".format(self.conport)
         f = urlopen(url)
         if PY2:
             rsp = f.read()
@@ -2027,7 +2026,7 @@ class PerRequestTestCase(unittest.TestCase):
                         Location("/foo",
                                  SetHandler("mod_python"),
                                  PythonHandler("mod_python.wsgi"),
-                                 PythonPath("[r'%s']+sys.path" % DOCUMENT_ROOT),
+                                 PythonPath("[r'{0!s}']+sys.path".format(DOCUMENT_ROOT)),
                                  PythonOption("mod_python.wsgi.application wsgitest::base_uri"),
                                  PythonDebug("On")))
         return c
@@ -2121,7 +2120,7 @@ class PerRequestTestCase(unittest.TestCase):
             #print 'expect{%s} got{%s}' % (expected_result, test_string)
 
         if failures:
-            msg = 'psp_parser parse errors for: %s' % (', '.join(failures))
+            msg = 'psp_parser parse errors for: {0!s}'.format((', '.join(failures)))
             self.fail(msg)
 
     def test_psp_error_conf(self):
@@ -2132,7 +2131,7 @@ class PerRequestTestCase(unittest.TestCase):
                         Directory(DOCUMENT_ROOT,
                                   SetHandler("mod_python"),
                                   PythonHandler("mod_python.psp"),
-                                  PythonOption('mod_python.session.database_directory "%s"' % TMP_DIR),
+                                  PythonOption('mod_python.session.database_directory "{0!s}"'.format(TMP_DIR)),
                                   PythonDebug("On")))
         return c
 
@@ -2160,10 +2159,10 @@ class PerRequestTestCase(unittest.TestCase):
         print("\n  * Testing Cookie.Cookie")
 
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/testz.py", skip_host=1)
         # this is three cookies, nastily formatted
-        conn.putheader("Host", "test_Cookie_Cookie:%s" % PORT)
+        conn.putheader("Host", "test_Cookie_Cookie:{0!s}".format(PORT))
         conn.putheader("Cookie", "spam=foo; path=blah;;eggs=bar;")
         conn.putheader("Cookie", "bar=foo")
         conn.endheaders()
@@ -2197,9 +2196,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         mc = "eggs=d049b2b61adb6a1d895646719a3dc30bcwQAAABzcGFt"
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/testz.py", skip_host=1)
-        conn.putheader("Host", "test_Cookie_MarshalCookie:%s" % PORT)
+        conn.putheader("Host", "test_Cookie_MarshalCookie:{0!s}".format(PORT))
         conn.putheader("Cookie", mc)
         conn.endheaders()
         response = conn.getresponse()
@@ -2218,9 +2217,9 @@ class PerRequestTestCase(unittest.TestCase):
              'mcgbG9uZyBsb25nIGxvbmcgc28gbG9uZyBidXQgd2UnbG'
              'wgZmluaXNoIGl0IHNvb24=')
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/testz.py", skip_host=1)
-        conn.putheader("Host", "test_Cookie_MarshalCookie:%s" % PORT)
+        conn.putheader("Host", "test_Cookie_MarshalCookie:{0!s}".format(PORT))
         conn.putheader("Cookie", mc)
         conn.endheaders()
         response = conn.getresponse()
@@ -2240,7 +2239,7 @@ class PerRequestTestCase(unittest.TestCase):
                         Directory(DOCUMENT_ROOT,
                                   SetHandler("mod_python"),
                                   PythonHandler("tests::Session_Session"),
-                                  PythonOption('mod_python.session.database_directory "%s"' % TMP_DIR),
+                                  PythonOption('mod_python.session.database_directory "{0!s}"'.format(TMP_DIR)),
                                   PythonOption('mod_python.session.application_path "/path"'),
                                   PythonOption('mod_python.session.application_domain "test_Session_Session"'),
                                   PythonDebug("On")))
@@ -2250,10 +2249,10 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing Session.Session")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         #conn.set_debuglevel(1000)
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_Session_Session:%s" % PORT)
+        conn.putheader("Host", "test_Session_Session:{0!s}".format(PORT))
         conn.endheaders()
         response = conn.getresponse()
         setcookie = response.getheader("set-cookie", None)
@@ -2275,17 +2274,17 @@ class PerRequestTestCase(unittest.TestCase):
         if 'domain' not in fields or fields['domain'] != 'test_Session_Session':
             self.fail("session did not contain expected 'domain'")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         #conn.set_debuglevel(1000)
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_Session_Session:%s" % PORT)
+        conn.putheader("Host", "test_Session_Session:{0!s}".format(PORT))
         conn.putheader("Cookie", setcookie)
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
         conn.close()
         if rsp != b"test ok":
-            self.fail("session did not accept our cookie: %s" % repr(rsp))
+            self.fail("session did not accept our cookie: {0!s}".format(repr(rsp)))
 
     def test_Session_illegal_sid_conf(self):
 
@@ -2295,7 +2294,7 @@ class PerRequestTestCase(unittest.TestCase):
                         Directory(DOCUMENT_ROOT,
                                   SetHandler("mod_python"),
                                   PythonHandler("tests::Session_Session"),
-                                  PythonOption('mod_python.session.database_directory "%s"' % TMP_DIR),
+                                  PythonOption('mod_python.session.database_directory "{0!s}"'.format(TMP_DIR)),
                                   PythonDebug("On")))
         return c
 
@@ -2303,9 +2302,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing Session with illegal session id value")
         bad_cookie = 'pysid=/path/traversal/attack/bad; path=/'
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_Session_Session:%s" % PORT)
+        conn.putheader("Host", "test_Session_Session:{0!s}".format(PORT))
         conn.putheader("Cookie", bad_cookie)
         conn.endheaders()
         response = conn.getresponse()
@@ -2315,10 +2314,10 @@ class PerRequestTestCase(unittest.TestCase):
         if status != 200 or not setcookie:
             self.fail("session id with illegal characters not replaced")
 
-        bad_cookie = 'pysid=%s; path=/' % ('abcdef'*64)
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        bad_cookie = 'pysid={0!s}; path=/'.format(('abcdef'*64))
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_Session_Session:%s" % PORT)
+        conn.putheader("Host", "test_Session_Session:{0!s}".format(PORT))
         conn.putheader("Cookie", bad_cookie)
         conn.endheaders()
         response = conn.getresponse()
@@ -2363,9 +2362,9 @@ class PerRequestTestCase(unittest.TestCase):
 
         print("\n  * Testing None handler")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py", skip_host=1)
-        conn.putheader("Host", "test_none_handler:%s" % PORT)
+        conn.putheader("Host", "test_none_handler:{0!s}".format(PORT))
         conn.endheaders()
         response = conn.getresponse()
         status = response.status
@@ -2479,15 +2478,15 @@ class PerRequestTestCase(unittest.TestCase):
     def test_publisher_auth_nested(self):
         print("\n  * Testing mod_python.publisher auth nested")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         #conn.set_debuglevel(1000)
         conn.putrequest("GET", "/tests.py/test_publisher_auth_nested", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_publisher_auth_nested", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_publisher_auth_nested", PORT))
         auth = base64.encodestring(b"spam:eggs").strip()
         if PY2:
-            conn.putheader("Authorization", "Basic %s" % auth)
+            conn.putheader("Authorization", "Basic {0!s}".format(auth))
         else:
-            conn.putheader("Authorization", "Basic %s" % auth.decode("latin1"))
+            conn.putheader("Authorization", "Basic {0!s}".format(auth.decode("latin1")))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -2509,14 +2508,14 @@ class PerRequestTestCase(unittest.TestCase):
     def test_publisher_auth_method_nested(self):
         print("\n  * Testing mod_python.publisher auth method nested")
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py/test_publisher_auth_method_nested/method", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_publisher_auth_method_nested", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_publisher_auth_method_nested", PORT))
         auth = base64.encodestring(b"spam:eggs").strip()
         if PY2:
-            conn.putheader("Authorization", "Basic %s" % auth)
+            conn.putheader("Authorization", "Basic {0!s}".format(auth))
         else:
-            conn.putheader("Authorization", "Basic %s" % auth.decode("latin1"))
+            conn.putheader("Authorization", "Basic {0!s}".format(auth.decode("latin1")))
         conn.endheaders()
         response = conn.getresponse()
         rsp = response.read()
@@ -2541,9 +2540,9 @@ class PerRequestTestCase(unittest.TestCase):
         # The contents of the authorization header is not relevant,
         # as long as it looks valid.
 
-        conn = http_connection("127.0.0.1:%s" % PORT)
+        conn = http_connection("127.0.0.1:{0!s}".format(PORT))
         conn.putrequest("GET", "/tests.py/test_publisher", skip_host=1)
-        conn.putheader("Host", "%s:%s" % ("test_publisher_auth_digest", PORT))
+        conn.putheader("Host", "{0!s}:{1!s}".format("test_publisher_auth_digest", PORT))
         conn.putheader("Authorization", 'Digest username="Mufasa", realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", uri="/dir/index.html", qop=auth, nc=00000001, cnonce="0a4f113b", response="6629fae49393a05397450978507c4ef1", opaque="5ccc069c403ebaf9f0171e9517f40e41"')
         conn.endheaders()
         response = conn.getresponse()
@@ -2567,10 +2566,10 @@ class PerRequestTestCase(unittest.TestCase):
         print("\n  * Testing mod_python.publisher security")
 
         def get_status(path):
-            conn = http_connection("127.0.0.1:%s" % PORT)
+            conn = http_connection("127.0.0.1:{0!s}".format(PORT))
             #conn.set_debuglevel(1000)
             conn.putrequest("GET", path, skip_host=1)
-            conn.putheader("Host", "test_publisher:%s" % PORT)
+            conn.putheader("Host", "test_publisher:{0!s}".format(PORT))
             conn.endheaders()
             response = conn.getresponse()
             status, response = response.status, response.read()
@@ -2579,43 +2578,43 @@ class PerRequestTestCase(unittest.TestCase):
 
         status, response = get_status("/tests.py/_SECRET_PASSWORD")
         if status != 403:
-            self.fail('Vulnerability : underscore prefixed attribute (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : underscore prefixed attribute ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/__ANSWER")
         if status != 403:
-            self.fail('Vulnerability : underscore prefixed attribute (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : underscore prefixed attribute ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/re")
         if status != 403:
-            self.fail('Vulnerability : module published (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : module published ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/OldStyleClassTest")
         if status != 403:
-            self.fail('Vulnerability : old style class published (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : old style class published ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/InstanceTest")
         if status != 403:
-            self.fail('Vulnerability : new style class published (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : new style class published ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/index/func_code")
         if status != 403:
-            self.fail('Vulnerability : function traversal (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : function traversal ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/old_instance/traverse/func_code")
         if status != 403:
-            self.fail('Vulnerability : old-style method traversal (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : old-style method traversal ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/instance/traverse/func_code")
         if status != 403:
-            self.fail('Vulnerability : new-style method traversal (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : new-style method traversal ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/test_dict/keys")
         if status != 403:
-            self.fail('Vulnerability : built-in type traversal (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : built-in type traversal ({0:d})\n{1!s}'.format(status, response))
 
         status, response = get_status("/tests.py/test_dict_keys")
         if status != 403:
-            self.fail('Vulnerability : built-in type publishing (%i)\n%s' % (status, response))
+            self.fail('Vulnerability : built-in type publishing ({0:d})\n{1!s}'.format(status, response))
 
     def test_publisher_iterator_conf(self):
         c = VirtualHost("*",
@@ -2831,7 +2830,7 @@ class PerRequestTestCase(unittest.TestCase):
         before, after = list(map(int, rsp.split("|")[1:]))
 
         if before != after:
-            self.fail("Memory before: %s, memory after: %s" % (before, after))
+            self.fail("Memory before: {0!s}, memory after: {1!s}".format(before, after))
 
 class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
     # this is a test case which requires a complete
@@ -2848,12 +2847,11 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
         self.makeConfig()
         self.startHttpd()
 
-        f = urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+        f = urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
         server_hdr = f.info()["Server"]
         f.close()
         self.failUnless(server_hdr.find("Python") > -1,
-                        "%s does not appear to load, Server header does not contain Python"
-                        % MOD_PYTHON_SO)
+                        "{0!s} does not appear to load, Server header does not contain Python".format(MOD_PYTHON_SO))
 
     def testVersionCheck(self):
 
@@ -2866,7 +2864,7 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
         self.makeConfig(c)
 
         self.startHttpd()
-        urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+        urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
         self.stopHttpd()
 
         # see what's in the log now
@@ -2888,7 +2886,7 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
 
             try:
                 self.startHttpd()
-                urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+                urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
                 self.stopHttpd()
 
                 time.sleep(0.1)
@@ -2912,7 +2910,7 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
 
         self.startHttpd()
 
-        f = urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+        f = urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
         if PY2:
             rsp = f.read()
         else:
@@ -2931,17 +2929,15 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
         t1 = time.time()
         print("    ", time.ctime())
         if os.name == "nt":
-            cmd = '%s -c 5 -n 5 http://127.0.0.1:%s/tests.py > NUL:' \
-                  % (ab, PORT)
+            cmd = '{0!s} -c 5 -n 5 http://127.0.0.1:{1!s}/tests.py > NUL:'.format(ab, PORT)
         else:
-            cmd = '%s -c 5 -n 5 http://127.0.0.1:%s/tests.py > /dev/null' \
-                  % (ab, PORT)
+            cmd = '{0!s} -c 5 -n 5 http://127.0.0.1:{1!s}/tests.py > /dev/null'.format(ab, PORT)
         print("    ", cmd)
         os.system(cmd)
         print("    ", time.ctime())
         t2 = time.time()
         if (t2 - t1) < 5:
-            self.fail("global_lock is broken (too quick): %f" % (t2 - t1))
+            self.fail("global_lock is broken (too quick): {0:f}".format((t2 - t1)))
 
     def testPerRequestTests(self):
 
@@ -3053,7 +3049,7 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
 
         self.startHttpd()
 
-        f = urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+        f = urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
         f.read()
         f.close()
 
@@ -3082,7 +3078,7 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
 
         self.startHttpd()
 
-        f = urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+        f = urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
         f.read()
         f.close()
 
@@ -3111,7 +3107,7 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
 
         self.startHttpd()
 
-        f = urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+        f = urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
         if PY2:
             rsp = f.read()
         else:
@@ -3121,11 +3117,11 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
         self.stopHttpd()
 
         if rsp != 'NO_FOOBAR':
-            self.fail('Failure on apache.exists_config_define() : %s'%rsp)
+            self.fail('Failure on apache.exists_config_define() : {0!s}'.format(rsp))
 
         self.startHttpd(extra="-DFOOBAR")
 
-        f = urlopen("http://127.0.0.1:%s/tests.py" % PORT)
+        f = urlopen("http://127.0.0.1:{0!s}/tests.py".format(PORT))
         if PY2:
             rsp = f.read()
         else:
@@ -3136,7 +3132,7 @@ class PerInstanceTestCase(unittest.TestCase, HttpdCtrl):
         self.stopHttpd()
 
         if rsp != 'FOOBAR':
-            self.fail('Failure on apache.exists_config_define() : %s'%rsp)
+            self.fail('Failure on apache.exists_config_define() : {0!s}'.format(rsp))
 
 def suite():
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mod_python?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:mod_python?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)