### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/lib/python/mod_python/Session.py
+++ b/lib/python/mod_python/Session.py
@@ -269,7 +269,7 @@ class BaseSession(dict):
 
     def load(self):
         dict = self.do_load()
-        if dict == None:
+        if dict is None:
             return 0
 
         if (time.time() - dict["_accessed"]) > dict["_timeout"]:

--- a/test/htdocs/tests.py
+++ b/test/htdocs/tests.py
@@ -410,7 +410,7 @@ class SimpleTestCase(unittest.TestCase):
         log = req.log_error
         log("req.get_get_remote_host(): {0!s}".format(repr(req.get_remote_host(apache.REMOTE_HOST))))
         log("req.get_get_remote_host(): {0!s}".format(repr(req.get_remote_host())))
-        if (req.get_remote_host(apache.REMOTE_HOST) != None) or \
+        if (req.get_remote_host(apache.REMOTE_HOST) is not None) or \
            (req.get_remote_host() != "127.0.0.1"):
             self.fail("remote host test failed: {0!s}".format(req.get_remote_host()))
 

--- a/test/test.py
+++ b/test/test.py
@@ -2263,7 +2263,7 @@ class PerRequestTestCase(unittest.TestCase):
         rsp = response.read()
         conn.close()
 
-        if rsp != b"test ok" or setcookie == None:
+        if rsp != b"test ok" or setcookie is None:
             self.fail("session did not set a cookie")
 
         parts = setcookie.split('; ')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mod_python?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:mod_python?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)